### PR TITLE
Referee search filtering

### DIFF
--- a/app/controllers/api/v1/referees_controller.rb
+++ b/app/controllers/api/v1/referees_controller.rb
@@ -8,7 +8,7 @@ module Api
       layout false
 
       def index
-        @referees = Referee.filtered_search(params)
+        @referees = Services::FilterReferees.new(search_params).filter
 
         json_string = RefereeSerializer.new(@referees).serialized_json
 
@@ -54,7 +54,11 @@ module Api
       end
 
       def permitted_params
-        params.permit(:id, :first_name, :last_name, :bio, :pronouns, :show_pronouns)
+        params.permit(:id, :first_name, :last_name, :bio, :pronouns, :show_pronouns, :search_by, :filter_by)
+      end
+
+      def search_params
+        permitted_params.to_h
       end
 
       def serializer_options

--- a/app/controllers/api/v1/referees_controller.rb
+++ b/app/controllers/api/v1/referees_controller.rb
@@ -58,7 +58,7 @@ module Api
       end
 
       def search_params
-        params.permit(:q, filter_by: %i[certifications national_governing_bodies]).to_h.deep_symbolize_keys
+        params.permit(:q, filter_by: [certifications: [], national_governing_bodies: []]).to_h.deep_symbolize_keys
       end
 
       def serializer_options

--- a/app/controllers/api/v1/referees_controller.rb
+++ b/app/controllers/api/v1/referees_controller.rb
@@ -8,7 +8,7 @@ module Api
       layout false
 
       def index
-        @referees = Referee.all
+        @referees = Referee.filtered_search(params)
 
         json_string = RefereeSerializer.new(@referees).serialized_json
 

--- a/app/controllers/api/v1/referees_controller.rb
+++ b/app/controllers/api/v1/referees_controller.rb
@@ -54,11 +54,11 @@ module Api
       end
 
       def permitted_params
-        params.permit(:id, :first_name, :last_name, :bio, :pronouns, :show_pronouns, :search_by, :filter_by)
+        params.permit(:id, :first_name, :last_name, :bio, :pronouns, :show_pronouns)
       end
 
       def search_params
-        permitted_params.to_h
+        params.permit(:q, filter_by: %i[certifications national_governing_bodies]).to_h.deep_symbolize_keys
       end
 
       def serializer_options

--- a/app/javascript/packs/MainApp/components/Referees.jsx
+++ b/app/javascript/packs/MainApp/components/Referees.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import axios from 'axios'
-import { Input } from 'semantic-ui-react'
+import { Input, Checkbox } from 'semantic-ui-react'
 
 class Referees extends Component {
   static propTypes = {
@@ -46,6 +46,13 @@ class Referees extends Component {
       })
   }
 
+  handleCheckboxChange = (e, { checked, value }) => {
+    axios.get('/api/v1/referees', { params: { filter_by: { certifications: [value] } } })
+      .then(({ data }) => {
+        this.setState({ referees: data.data })
+      })
+  }
+
   render() {
     const { referees } = this.state
 
@@ -53,6 +60,7 @@ class Referees extends Component {
       <div>
         <h1>Referee List View</h1>
         <Input placeholder="Search..." onChange={this.handleSearchChange} />
+        <Checkbox label="Snitch Certification" value="snitch" onChange={this.handleCheckboxChange} />
         <ul>
           {referees.map(this.renderListItem)}
         </ul>

--- a/app/javascript/packs/MainApp/components/Referees.jsx
+++ b/app/javascript/packs/MainApp/components/Referees.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import axios from 'axios'
+import { Input } from 'semantic-ui-react'
 
 class Referees extends Component {
   static propTypes = {
@@ -38,12 +39,20 @@ class Referees extends Component {
     )
   }
 
+  handleSearchChange = (e, { value }) => {
+    axios.get('/api/v1/referees', { params: { q: value } })
+      .then(({ data }) => {
+        this.setState({ referees: data.data })
+      })
+  }
+
   render() {
     const { referees } = this.state
 
     return (
       <div>
         <h1>Referee List View</h1>
+        <Input placeholder="Search..." onChange={this.handleSearchChange} />
         <ul>
           {referees.map(this.renderListItem)}
         </ul>

--- a/app/models/referee.rb
+++ b/app/models/referee.rb
@@ -40,4 +40,19 @@ class Referee < ApplicationRecord
 
   has_many :test_results, dependent: :destroy
   has_many :test_attempts, dependent: :destroy
+
+  def self.filtered_search(params = {})
+    filter_params = params.delete(:filter_by)
+    search_query = params.delete(:q)
+    return Referee.all if filter_params.blank? && search_query.blank?
+
+    if filter_params.present?
+      # get certification level
+      # get ngb id
+    end
+
+    if search_query.present?
+      Referee.where('first_name LIKE :query OR last_name LIKE :query', query: "%#{search_query}%")
+    end
+  end
 end

--- a/app/models/referee.rb
+++ b/app/models/referee.rb
@@ -40,19 +40,4 @@ class Referee < ApplicationRecord
 
   has_many :test_results, dependent: :destroy
   has_many :test_attempts, dependent: :destroy
-
-  def self.filtered_search(params = {})
-    filter_params = params.delete(:filter_by)
-    search_query = params.delete(:q)
-    return Referee.all if filter_params.blank? && search_query.blank?
-
-    if filter_params.present?
-      # get certification level
-      # get ngb id
-    end
-
-    if search_query.present?
-      Referee.where('first_name LIKE :query OR last_name LIKE :query', query: "%#{search_query}%")
-    end
-  end
 end

--- a/app/services/filter_referees.rb
+++ b/app/services/filter_referees.rb
@@ -1,0 +1,50 @@
+module Services
+  class FilterReferees
+    attr_accessor :search_query, :filter_by, :relation
+
+    def initialize(params)
+      @search_query = params.delete(:q)
+      @filter_by = params.delete(:filter_by)
+      @relation = Referee.all
+    end
+
+    def filter
+      return relation if filter_by.blank? && search_query.blank?
+
+      sanitize_params
+
+      relation = search_by_name if search_query.present?
+      relation = filter_by_certification if filter_by['certifications'].present?
+      relation = filter_by_national_governing_body if filter_by['national_governing_bodies'].present?
+
+      relation || []
+    end
+
+    private
+
+    def sanitize_params
+      @search_query = JSON.parse(search_query) if search_query.present?
+      @filter_by = JSON.parse(filter_by) if filter_by.present?
+    end
+
+    def search_by_name
+      relation.where('first_name LIKE :query OR last_name LIKE :query', query: "%#{search_query}%")
+    end
+
+    def filter_by_certification
+      certification_levels = filter_by.fetch('certifications')
+      return relation if certification_levels.blank?
+
+      relation.joins(:certifications).where(certifications: { level: certification_levels })
+    end
+
+    def filter_by_national_governing_body
+      national_governing_body_ids = filter_by.fetch('national_governing_bodies')
+      return relation if national_governing_body_ids.blank?
+
+      relation
+        .joins(:national_governing_bodies)
+        .where(national_governing_bodies: { id: national_governing_body_ids })
+    end
+  end
+end

--- a/app/services/filter_referees.rb
+++ b/app/services/filter_referees.rb
@@ -11,35 +11,31 @@ module Services
     def filter
       return relation if filter_by.blank? && search_query.blank?
 
-      sanitize_params
+      @relation = search_by_name if search_query.present?
 
-      relation = search_by_name if search_query.present?
-      relation = filter_by_certification if filter_by['certifications'].present?
-      relation = filter_by_national_governing_body if filter_by['national_governing_bodies'].present?
+      if filter_by.present?
+        @relation = filter_by_certification if filter_by[:certifications].present?
+        @relation = filter_by_national_governing_body if filter_by[:national_governing_bodies].present?
+      end
 
       relation || []
     end
 
     private
 
-    def sanitize_params
-      @search_query = JSON.parse(search_query) if search_query.present?
-      @filter_by = JSON.parse(filter_by) if filter_by.present?
-    end
-
     def search_by_name
-      relation.where('first_name LIKE :query OR last_name LIKE :query', query: "%#{search_query}%")
+      relation.where("coalesce(first_name, '') || ' ' || coalesce(last_name, '') ilike '%' || ? || '%'", search_query)
     end
 
     def filter_by_certification
-      certification_levels = filter_by.fetch('certifications')
+      certification_levels = filter_by.fetch(:certifications)
       return relation if certification_levels.blank?
 
       relation.joins(:certifications).where(certifications: { level: certification_levels })
     end
 
     def filter_by_national_governing_body
-      national_governing_body_ids = filter_by.fetch('national_governing_bodies')
+      national_governing_body_ids = filter_by.fetch(:national_governing_bodies)
       return relation if national_governing_body_ids.blank?
 
       relation

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,7 @@ module RefereeHub
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+    config.enable_dependency_loading = true
+    config.autoload_paths += %W[#{config.root}/app #{config.root}/app/services]
   end
 end

--- a/spec/controllers/api/v1/referees_controller_spec.rb
+++ b/spec/controllers/api/v1/referees_controller_spec.rb
@@ -19,6 +19,55 @@ RSpec.describe Api::V1::RefereesController, type: :controller do
 
       expect(response_data.length).to eq 3
     end
+
+    context 'when searching' do
+      before { referees.first.update!(first_name: 'Test') }
+
+      subject { get :index, params: { q: 'test' } }
+
+      it 'only returns the matching referee' do
+        subject
+
+        response_data = JSON.parse(response.body)['data']
+
+        expect(response_data.length).to eq 1
+        expect(response_data[0]['id'].to_i).to eq referees.first.id
+      end
+    end
+
+    context 'when filtering by certification' do
+      let!(:certification) { create :certification, :snitch }
+
+      before { referees.first.update!(certifications: [certification]) }
+
+      subject { get :index, params: { filter_by: { certifications: ['snitch'] } } }
+
+      it 'only returns the matching referee' do
+        subject
+
+        response_data = JSON.parse(response.body)['data']
+
+        expect(response_data.length).to eq 1
+        expect(response_data[0]['id'].to_i).to eq referees.first.id
+      end
+    end
+
+    context 'when filtering by national governing body' do
+      let!(:ngb) { create :national_governing_body }
+
+      before { referees.first.update!(national_governing_bodies: [ngb]) }
+
+      subject { get :index, params: { filter_by: { national_governing_bodies: [ngb.id] } } }
+
+      it 'only returns the matching referee' do
+        subject
+
+        response_data = JSON.parse(response.body)['data']
+
+        expect(response_data.length).to eq 1
+        expect(response_data[0]['id'].to_i).to eq referees.first.id
+      end
+    end
   end
 
   describe 'GET #show' do

--- a/spec/services/filter_referees_spec.rb
+++ b/spec/services/filter_referees_spec.rb
@@ -1,0 +1,144 @@
+require 'rails_helper'
+require 'json'
+
+RSpec.describe Services::FilterReferees do
+  let(:ngb) { create :national_governing_body }
+  let(:cert) { create :certification, :snitch }
+  let(:referees) { create_list :referee, 3 }
+  let(:search_query) { 'test' }
+  let(:certifications) { ['snitch'] }
+  let(:ngbs) { [ngb.id] }
+  let(:filter_by) { { certifications: certifications, national_governing_bodies: ngbs } }
+  let(:params) do
+    {
+      q: search_query,
+      filter_by: filter_by
+    }
+  end
+
+  before do
+    referees.first.update(certifications: [cert])
+    referees[1].update(first_name: 'test')
+    referees.last.update(national_governing_bodies: [ngb])
+  end
+
+  subject { described_class.new(params).filter }
+
+  context 'when only a search query exists' do
+    let(:filter_by) { nil }
+
+    it 'should return the referee that matches the search query' do
+      expect(subject.length).to eq 1
+      expect(subject.first.id).to eq referees[1].id
+    end
+  end
+
+  context 'when only a certification filter exists' do
+    let(:search_query) { nil }
+    let(:ngbs) { nil }
+
+    it 'should return the referee that matches the filter query' do
+      expect(subject.length).to eq 1
+      expect(subject.first.id).to eq referees.first.id
+    end
+  end
+
+  context 'when only a national governing body filter exists' do
+    let(:search_query) { nil }
+    let(:certifications) { nil }
+
+    it 'should return the referee that matches the filter query' do
+      expect(subject.length).to eq 1
+      expect(subject.first.id).to eq referees.last.id
+    end
+  end
+
+  context 'when certification and ngb fields exist' do
+    let(:search_query) { nil }
+
+    context 'and no referee meets both criteria' do
+      it 'should not return a referee' do
+        expect(subject.length).to eq 0
+      end
+    end
+
+    context 'and a referee meets both criteria' do
+      before { referees.last.update(certifications: [cert]) }
+
+      it 'should return the matching referee' do
+        expect(subject.length).to eq 1
+        expect(subject.first.id).to eq referees.last.id
+      end
+    end
+  end
+
+  context 'when searching by name' do
+    let!(:referee) { create :referee }
+    let(:search_query) { 'nap' }
+    let(:params) { { q: search_query } }
+
+    before { referee.update(first_name: first_name, last_name: last_name) }
+
+    context 'when values are null' do
+      context 'and first_name is null but last_name matches' do
+        let(:first_name) { nil }
+        let(:last_name) { 'Napperton' }
+
+        it 'should return the referee' do
+          expect(subject.length).to eq 1
+          expect(subject.first.id).to eq referee.id
+        end
+      end
+
+      context 'and last_name is null but first_name matches' do
+        let(:first_name) { 'Nap' }
+        let(:last_name) { nil }
+
+        it 'should return the referee' do
+          expect(subject.length).to eq 1
+          expect(subject.first.id).to eq referee.id
+        end
+      end
+
+      context 'and both first_name and last_name are null' do
+        let(:first_name) { nil }
+        let(:last_name) { nil }
+
+        it 'should return an empty array' do
+          expect(subject.length).to eq 0
+        end
+      end
+    end
+
+    context 'when values are present' do
+      context 'and first name matches but last name doesnt' do
+        let(:first_name) { 'Nap' }
+        let(:last_name) { 'Blahburg' }
+
+        it 'should return the referee' do
+          expect(subject.length).to eq 1
+          expect(subject.first.id).to eq referee.id
+        end
+      end
+
+      context 'and last name matches but first name doesnt' do
+        let(:first_name) { 'Blangdon' }
+        let(:last_name) { 'Napperton' }
+
+        it 'should return the referee' do
+          expect(subject.length).to eq 1
+          expect(subject.first.id).to eq referee.id
+        end
+      end
+
+      context 'and neither name matches' do
+        let(:first_name) { 'Mark' }
+        let(:last_name) { 'Wahlberg' }
+
+        it 'should return an empty array' do
+          expect(subject.length).to eq 0
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR allows the client to search and filter by first name, last name, certification, and national governing body. Some of the frontend actions have been stubbed out for testing, but the bulk of that work will be done at in a separate PR.