### PR TITLE
Avoids lazy loading referee list

### DIFF
--- a/app/controllers/api/v1/referees_controller.rb
+++ b/app/controllers/api/v1/referees_controller.rb
@@ -10,7 +10,11 @@ module Api
       def index
         @referees = Services::FilterReferees.new(search_params).filter
 
-        json_string = RefereeSerializer.new(@referees, serializer_options).serialized_json
+        json_string = RefereeSerializer.new(
+          @referees,
+          include: %i[national_governing_bodies certifications],
+          params: { current_user: current_referee, include_tests: false }
+        ).serialized_json
 
         render json: json_string, status: :ok
       end
@@ -73,7 +77,7 @@ module Api
       def serializer_options
         @serializer_options ||= {
           include: %i[national_governing_bodies certifications test_attempts test_results],
-          params: { current_user: current_referee }
+          params: { current_user: current_referee, include_tests: true }
         }
       end
     end

--- a/app/serializers/referee_serializer.rb
+++ b/app/serializers/referee_serializer.rb
@@ -52,6 +52,6 @@ class RefereeSerializer
 
   has_many :national_governing_bodies
   has_many :certifications
-  has_many :test_results
-  has_many :test_attempts
+  has_many :test_results, if: proc { |params| params[:include_tests] }
+  has_many :test_attempts, if: proc { |params| params[:include_tests] }
 end

--- a/app/services/filter_referees.rb
+++ b/app/services/filter_referees.rb
@@ -6,7 +6,7 @@ module Services
       @search_query = params.delete(:q)
       @certifications = params.delete(:certifications)
       @national_governing_bodies = params.delete(:national_governing_bodies)
-      @relation = Referee.all
+      @relation = Referee.includes(:certifications, :national_governing_bodies).all
     end
 
     def filter
@@ -28,15 +28,13 @@ module Services
     def filter_by_certification
       return relation if certifications.blank?
 
-      relation.joins(:certifications).where(certifications: { level: certifications })
+      relation.where(certifications: { level: certifications })
     end
 
     def filter_by_national_governing_body
       return relation if national_governing_bodies.blank?
 
-      relation
-        .joins(:national_governing_bodies)
-        .where(national_governing_bodies: { id: national_governing_bodies })
+      relation.where(national_governing_bodies: { id: national_governing_bodies })
     end
   end
 end


### PR DESCRIPTION
Speeds up loading referee list by more than 10x. Locally with 270 referees, 425 NGB associations, and 225 given certifications the backend now takes under 300ms to send the referee list to the frontend instead of 3.5s before. So the difference should be even bigger in production.