### PR TITLE
Allow all associations to be returned on an index call

### DIFF
--- a/app/controllers/api/v1/referees_controller.rb
+++ b/app/controllers/api/v1/referees_controller.rb
@@ -8,7 +8,8 @@ module Api
       layout false
 
       def index
-        @referees = Services::FilterReferees.new(search_params).filter
+        referee_ids = Services::FilterReferees.new(search_params).filter
+        @referees = Referee.where(id: referee_ids)
 
         json_string = RefereeSerializer.new(
           @referees,

--- a/app/controllers/api/v1/referees_controller.rb
+++ b/app/controllers/api/v1/referees_controller.rb
@@ -9,11 +9,11 @@ module Api
 
       def index
         referee_ids = Services::FilterReferees.new(search_params).filter
-        @referees = Referee.where(id: referee_ids)
+        @referees = Referee.includes(:national_governing_bodies, :certifications).where(id: referee_ids)
 
         json_string = RefereeSerializer.new(
           @referees,
-          include: %i[national_governing_bodies certifications],
+          include: [:certifications],
           params: { current_user: current_referee, include_tests: false }
         ).serialized_json
 
@@ -77,7 +77,7 @@ module Api
 
       def serializer_options
         @serializer_options ||= {
-          include: %i[national_governing_bodies certifications test_attempts test_results],
+          include: %i[certifications test_attempts test_results],
           params: { current_user: current_referee, include_tests: true }
         }
       end

--- a/app/javascript/packs/MainApp/components/RefereeTable.jsx
+++ b/app/javascript/packs/MainApp/components/RefereeTable.jsx
@@ -14,7 +14,10 @@ const refereePropTypes = {
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   certifications: PropTypes.arrayOf(PropTypes.string).isRequired,
-  nationalGoverningBodies: PropTypes.arrayOf(PropTypes.string).isRequired,
+  nationalGoverningBodies: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string,
+    name: PropTypes.string
+  })).isRequired,
   isCurrentReferee: PropTypes.bool
 }
 
@@ -36,6 +39,7 @@ const TableRow = (props) => {
   )
 
   const nameIcon = isCurrentReferee ? <Label ribbon color="blue">You</Label> : <Icon name="zoom" />
+  const ngbNames = nationalGoverningBodies.map(ngb => ngb.name).join(', ')
 
   return (
     <Table.Row onClick={() => onRefereeClick(id)} style={{ cursor: 'pointer' }}>
@@ -44,7 +48,7 @@ const TableRow = (props) => {
         {' '}
         {name}
       </Table.Cell>
-      <Table.Cell>{nationalGoverningBodies.join(', ')}</Table.Cell>
+      <Table.Cell>{ngbNames}</Table.Cell>
       {certificationArray.map(renderCertificationCell)}
     </Table.Row>
   )

--- a/app/javascript/packs/MainApp/components/Referees.jsx
+++ b/app/javascript/packs/MainApp/components/Referees.jsx
@@ -22,18 +22,11 @@ class Referees extends Component {
   componentDidMount() {
     axios
       .get('api/v1/national_governing_bodies')
-      .then(({ data: { data } }) => {
-        this.setState({
-          nationalGoverningBodies: data.map(nationalGoverningBody => ({
-            id: nationalGoverningBody.id,
-            name: nationalGoverningBody.attributes.name
-          }))
-        })
-      })
+      .then(this.setAllNGBs)
       .then(this.handleSearch)
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(_prevProps, prevState) {
     const { nameSearch: oldName, nationalGoverningBodySearch: oldNGB, certificationSearch: oldCert } = this.state
     const { nameSearch: newName, nationalGoverningBodySearch: newNGB, certificationSearch: newCert } = prevState
 
@@ -71,6 +64,15 @@ class Referees extends Component {
     this.setState({
       referees,
       nationalGoverningBodies
+    })
+  }
+
+  setAllNGBs = ({ data: { data } }) => {
+    this.setState({
+      nationalGoverningBodies: data.map(nationalGoverningBody => ({
+        id: nationalGoverningBody.id,
+        name: nationalGoverningBody.attributes.name
+      }))
     })
   }
 

--- a/app/serializers/referee_serializer.rb
+++ b/app/serializers/referee_serializer.rb
@@ -50,8 +50,8 @@ class RefereeSerializer
     current_user && current_user.id == referee.id
   end
 
-  has_many :national_governing_bodies
-  has_many :certifications
+  has_many :national_governing_bodies, serializer: :national_governing_body
+  has_many :certifications, serializer: :certification
   has_many :test_results, if: proc { |params| params[:include_tests] }
   has_many :test_attempts, if: proc { |params| params[:include_tests] }
 end

--- a/app/services/filter_referees.rb
+++ b/app/services/filter_referees.rb
@@ -16,7 +16,7 @@ module Services
       @relation = filter_by_certification if certifications.present?
       @relation = filter_by_national_governing_body if national_governing_bodies.present?
 
-      relation || []
+      relation.pluck(:id)
     end
 
     private

--- a/spec/controllers/api/v1/referees_controller_spec.rb
+++ b/spec/controllers/api/v1/referees_controller_spec.rb
@@ -50,6 +50,24 @@ RSpec.describe Api::V1::RefereesController, type: :controller do
         expect(response_data.length).to eq 1
         expect(response_data[0]['id'].to_i).to eq referees.first.id
       end
+
+      context 'when a referee has more than one certification' do
+        let(:assistant_certification) { create :certification }
+
+        before { referees.first.update!(certifications: [certification, assistant_certification]) }
+
+        it 'should return both associations' do
+          subject
+
+          response_data = JSON.parse(response.body)['data']
+          cert_data = response_data[0]['relationships']['certifications']['data']
+
+          expect(response_data.length).to eq 1
+          expect(cert_data.length).to eq 2
+          expect(cert_data[0]['id'].to_i).to eq certification.id
+          expect(cert_data[1]['id'].to_i).to eq assistant_certification.id
+        end
+      end
     end
 
     context 'when filtering by national governing body' do
@@ -66,6 +84,24 @@ RSpec.describe Api::V1::RefereesController, type: :controller do
 
         expect(response_data.length).to eq 1
         expect(response_data[0]['id'].to_i).to eq referees.first.id
+      end
+
+      context 'when a referee has more than one national governing body' do
+        let!(:other_ngb) { create :national_governing_body }
+
+        before { referees.first.update!(national_governing_bodies: [ngb, other_ngb]) }
+
+        it 'returns both associations' do
+          subject
+
+          response_data = JSON.parse(response.body)['data']
+          ngb_data = response_data[0]['relationships']['national_governing_bodies']['data']
+
+          expect(response_data.length).to eq 1
+          expect(ngb_data.length).to eq 2
+          expect(ngb_data[0]['id'].to_i).to eq ngb.id
+          expect(ngb_data[1]['id'].to_i).to eq other_ngb.id
+        end
       end
     end
   end

--- a/spec/services/filter_referees_spec.rb
+++ b/spec/services/filter_referees_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Services::FilterReferees do
 
     it 'should return the referee that matches the search query' do
       expect(subject.length).to eq 1
-      expect(subject.first.id).to eq referees[1].id
+      expect(subject.first).to eq referees[1].id
     end
   end
 
@@ -40,7 +40,7 @@ RSpec.describe Services::FilterReferees do
 
     it 'should return the referee that matches the filter query' do
       expect(subject.length).to eq 1
-      expect(subject.first.id).to eq referees.first.id
+      expect(subject.first).to eq referees.first.id
     end
   end
 
@@ -50,7 +50,7 @@ RSpec.describe Services::FilterReferees do
 
     it 'should return the referee that matches the filter query' do
       expect(subject.length).to eq 1
-      expect(subject.first.id).to eq referees.last.id
+      expect(subject.first).to eq referees.last.id
     end
   end
 
@@ -68,7 +68,7 @@ RSpec.describe Services::FilterReferees do
 
       it 'should return the matching referee' do
         expect(subject.length).to eq 1
-        expect(subject.first.id).to eq referees.last.id
+        expect(subject.first).to eq referees.last.id
       end
     end
   end
@@ -87,7 +87,7 @@ RSpec.describe Services::FilterReferees do
 
         it 'should return the referee' do
           expect(subject.length).to eq 1
-          expect(subject.first.id).to eq referee.id
+          expect(subject.first).to eq referee.id
         end
       end
 
@@ -97,7 +97,7 @@ RSpec.describe Services::FilterReferees do
 
         it 'should return the referee' do
           expect(subject.length).to eq 1
-          expect(subject.first.id).to eq referee.id
+          expect(subject.first).to eq referee.id
         end
       end
 
@@ -118,7 +118,7 @@ RSpec.describe Services::FilterReferees do
 
         it 'should return the referee' do
           expect(subject.length).to eq 1
-          expect(subject.first.id).to eq referee.id
+          expect(subject.first).to eq referee.id
         end
       end
 
@@ -128,7 +128,7 @@ RSpec.describe Services::FilterReferees do
 
         it 'should return the referee' do
           expect(subject.length).to eq 1
-          expect(subject.first.id).to eq referee.id
+          expect(subject.first).to eq referee.id
         end
       end
 


### PR DESCRIPTION
This PR returns the ids from the filter referees service, this adds an extra query but because it's an indexed field should still have the performance improvement made by lazy loading the associations. I also made a couple of changes to the how we filter by NGB, allowing all NGBs to be filtered instead of only the ones that already have the association. Fixes #57 