### PR TITLE
Handle certification renewal

### DIFF
--- a/app/controllers/api/v1/referee_certifications_controller.rb
+++ b/app/controllers/api/v1/referee_certifications_controller.rb
@@ -1,0 +1,39 @@
+module Api
+  module V1
+    class RefereeCertificationsController < ::ApplicationController
+      before_action :authenticate_referee!
+      before_action :find_referee_certification, only: :update
+      skip_before_action :verify_authenticity_token
+
+      layout false
+
+      def index
+        @referee_certifications = current_referee.referee_certifications
+
+        json_string = RefereeCertificationSerializer.new(@referee_certifications).serialized_json
+
+        render json: json_string, status: :ok
+      end
+
+      def update
+        if @referee_certification.update!(permitted_params)
+          json_string = RefereeCertificationSerializer.new(@referee_certification)
+
+          render json: json_string, status: :ok
+        else
+          render json: { error: @referee_certification.errors.message }, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      def find_referee_certification
+        @referee_certification = current_referee.referee_certifications.find_by(id: params[:id])
+      end
+
+      def permitted_params
+        params.permit(:needs_renewal_at)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/referees_controller.rb
+++ b/app/controllers/api/v1/referees_controller.rb
@@ -83,7 +83,7 @@ module Api
 
       def serializer_options
         @serializer_options ||= {
-          include: %i[certifications national_governing_bodies test_attempts test_results],
+          include: %i[referee_certifications certifications national_governing_bodies test_attempts test_results],
           params: { current_user: current_referee, include_tests: true }
         }
       end

--- a/app/controllers/api/v1/referees_controller.rb
+++ b/app/controllers/api/v1/referees_controller.rb
@@ -18,7 +18,7 @@ module Api
 
         json_string = RefereeSerializer.new(
           @referees,
-          include: [:certifications],
+          include: [:referee_certifications],
           params: { current_user: current_referee, include_tests: false },
           meta: { page: page, total: referee_total }
         ).serialized_json

--- a/app/controllers/classmarker_controller.rb
+++ b/app/controllers/classmarker_controller.rb
@@ -42,8 +42,10 @@ class ClassmarkerController < ApplicationController
     referee = Referee.find_by(id: results_data['cm_user_id'])
     test_level = determine_level(test_data['test_name'])
 
-    create_test_attempt(test_level, referee) if referee.present?
-    create_test_results(results_data, test_level, referee) if referee.present?
+    if referee.present? && !in_cool_down_period?(referee, test_level)
+      create_test_attempt(test_level, referee)
+      create_test_results(results_data, test_level, referee)
+    end
   end
 
   def hmac_header_valid?
@@ -111,5 +113,14 @@ class ClassmarkerController < ApplicationController
     return 'head' if /head/i.match?(test_name)
 
     'snitch'
+  end
+
+  def in_cool_down_period?(referee, test_level)
+    return false unless referee
+
+    # if more than one test_attempt exists for the test level and the latest attempt is in the cool down period
+    latest_test_attempt = referee.test_attempts.where(test_level: test_level).order('created_at DESC').first
+
+    latest_test_attempt.try(:in_cool_down_period?, false)
   end
 end

--- a/app/javascript/packs/MainApp/components/RefereeProfile.jsx
+++ b/app/javascript/packs/MainApp/components/RefereeProfile.jsx
@@ -9,7 +9,7 @@ import RefereeProfileEdit from './RefereeProfileEdit'
 import ProfileContent from './ProfileContent'
 import CertificationContent from './CertificationContent'
 
-const NGBS_WITH_OLD_TEST_REQUIREMENT = ['Australia', 'Switzerland', 'Peru']
+const NGBS_WITH_OLD_TEST_REQUIREMENT = ['Australia', 'Peru']
 
 class RefereeProfile extends Component {
   static propTypes = {

--- a/app/javascript/packs/MainApp/components/Referees.jsx
+++ b/app/javascript/packs/MainApp/components/Referees.jsx
@@ -44,8 +44,8 @@ class Referees extends Component {
     const certifications = new Map()
 
     included.forEach((include) => {
-      if (include.type === 'certification') {
-        certifications.set(include.id, include.attributes.level);
+      if (include.type === 'referee_certification' && !include.attributes.needs_renewal_at) {
+        certifications.set(include.id, include.attributes.level)
       }
     })
 
@@ -54,7 +54,7 @@ class Referees extends Component {
       .map(({ id, attributes, relationships }) => ({
         id,
         name: `${attributes.first_name} ${attributes.last_name}`.trim(),
-        certifications: relationships.certifications.data.map(
+        certifications: relationships.referee_certifications.data.map(
           certification => certifications.get(certification.id)
         ),
         nationalGoverningBodies: relationships.national_governing_bodies.data.map(

--- a/app/models/national_governing_body.rb
+++ b/app/models/national_governing_body.rb
@@ -14,4 +14,5 @@
 class NationalGoverningBody < ApplicationRecord
   has_many :referee_locations, dependent: :destroy
   has_many :referees, through: :referee_locations
+  has_many :certified_referees, -> { certified }, through: :referee_locations, source: :referee
 end

--- a/app/models/referee.rb
+++ b/app/models/referee.rb
@@ -43,5 +43,7 @@ class Referee < ApplicationRecord
   has_many :test_results, dependent: :destroy
   has_many :test_attempts, dependent: :destroy
 
+  scope :certified, -> { joins(:certifications).group('referees.id') }
+
   self.per_page = 25
 end

--- a/app/models/referee_certification.rb
+++ b/app/models/referee_certification.rb
@@ -3,6 +3,7 @@
 # Table name: referee_certifications
 #
 #  id               :bigint(8)        not null, primary key
+#  needs_renewal_at :datetime
 #  received_at      :datetime
 #  renewed_at       :datetime
 #  revoked_at       :datetime

--- a/app/models/test_attempt.rb
+++ b/app/models/test_attempt.rb
@@ -29,4 +29,8 @@ class TestAttempt < ApplicationRecord
       self.next_attempt_at = Time.now.utc + 72.hours
     end
   end
+
+  def in_cool_down_period?
+    Time.now.utc < next_attempt_at
+  end
 end

--- a/app/models/test_result.rb
+++ b/app/models/test_result.rb
@@ -54,6 +54,14 @@ class TestResult < ApplicationRecord
 
   def update_certification(ref_certification, datetime_key)
     ref_certification[datetime_key] = Time.zone.now
+    ref_certification.needs_renewal_at = determine_needs_renewal(datetime_key)
+
     ref_certification.save!
+  end
+
+  def determine_needs_renewal(datetime_key)
+    return Time.zone.now if datetime_key == 'revoked_at'
+
+    nil
   end
 end

--- a/app/serializers/referee_certification_serializer.rb
+++ b/app/serializers/referee_certification_serializer.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: referee_certifications
+#
+#  id               :bigint(8)        not null, primary key
+#  needs_renewal_at :datetime
+#  received_at      :datetime
+#  renewed_at       :datetime
+#  revoked_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  certification_id :integer          not null
+#  referee_id       :integer          not null
+
+class RefereeCertificationSerializer
+  include FastJsonapi::ObjectSerializer
+
+  attributes :needs_renewal_at,
+             :received_at,
+             :renewed_at,
+             :revoked_at,
+             :referee_id,
+             :certification_id
+end

--- a/app/serializers/referee_certification_serializer.rb
+++ b/app/serializers/referee_certification_serializer.rb
@@ -21,4 +21,9 @@ class RefereeCertificationSerializer
              :revoked_at,
              :referee_id,
              :certification_id
+
+  attribute :level do |ref_cert, params|
+    cert = Certification.find_by id: ref_cert.certification_id
+    cert.level
+  end
 end

--- a/app/serializers/referee_serializer.rb
+++ b/app/serializers/referee_serializer.rb
@@ -52,6 +52,7 @@ class RefereeSerializer
 
   has_many :national_governing_bodies, serializer: :national_governing_body
   has_many :referee_certifications, serializer: :referee_certification
+  has_many :certifications, serializer: :certification
   has_many :test_results, if: proc { |params| params[:include_tests] }
   has_many :test_attempts, if: proc { |params| params[:include_tests] }
 end

--- a/app/serializers/referee_serializer.rb
+++ b/app/serializers/referee_serializer.rb
@@ -51,7 +51,7 @@ class RefereeSerializer
   end
 
   has_many :national_governing_bodies, serializer: :national_governing_body
-  has_many :certifications, serializer: :certification
+  has_many :referee_certifications, serializer: :referee_certification
   has_many :test_results, if: proc { |params| params[:include_tests] }
   has_many :test_attempts, if: proc { |params| params[:include_tests] }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :referees, only: %i[index show update]
       resources :national_governing_bodies, only: %i[index show]
+      resources :referee_certifications, only: %i[index update]
     end
   end
 

--- a/db/migrate/20181103181905_add_needs_renewal_to_referee_certifications.rb
+++ b/db/migrate/20181103181905_add_needs_renewal_to_referee_certifications.rb
@@ -1,0 +1,5 @@
+class AddNeedsRenewalToRefereeCertifications < ActiveRecord::Migration[5.2]
+  def change
+    add_column :referee_certifications, :needs_renewal_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_02_002721) do
+ActiveRecord::Schema.define(version: 2018_11_03_181905) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 2018_10_02_002721) do
     t.datetime "renewed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "needs_renewal_at"
     t.index ["referee_id", "certification_id"], name: "index_referee_certifications_on_referee_id_and_certification_id", unique: true, where: "(revoked_at IS NULL)"
   end
 

--- a/spec/controllers/api/v1/referee_certifications_controller_spec.rb
+++ b/spec/controllers/api/v1/referee_certifications_controller_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::RefereeCertificationsController, type: :controller do
+  describe 'GET #index' do
+    let!(:referee) { create :referee }
+    let!(:assistant) { create :referee_certification, referee: referee }
+    let!(:snitch) { create :referee_certification, :snitch, referee: referee }
+    let!(:head) { create :referee_certification, :head, referee: referee }
+
+    before { sign_in referee }
+
+    subject { get :index }
+
+    it 'returns http success' do
+      subject
+
+      expect(response).to have_http_status(:successful)
+    end
+
+    it 'returns all of the referees certifications' do
+      subject
+
+      response_data = JSON.parse(response.body)['data']
+
+      expect(response_data.length).to eq 3
+    end
+
+    context 'when there is not a signed in ref' do
+      before { sign_out referee }
+
+      it 'redirects to the login' do
+        subject
+
+        expect(response).to have_http_status(:found)
+      end
+    end
+  end
+
+  describe 'POST #update' do
+    let!(:referee) { create :referee }
+    let!(:assistant) { create :referee_certification, referee: referee }
+
+    before { sign_in referee }
+
+    subject { post :update, params: body_data }
+
+    context 'with valid params' do
+      let(:body_data) { { id: assistant.id, needs_renewal_at: Time.zone.now } }
+
+      it 'returns http success' do
+        subject
+
+        expect(response).to have_http_status(:successful)
+      end
+
+      it 'updates the referee certification' do
+        subject
+
+        expect(assistant.reload.needs_renewal_at).to_not be_nil
+      end
+    end
+
+    context 'with invalid params' do
+      let(:body_data) { { id: assistant.id, blah: 'this is nonsense' } }
+
+      it 'does not update the record' do
+        subject
+
+        expect(assistant.reload.needs_renewal_at).to be_nil
+      end
+    end
+  end
+end

--- a/spec/factories/referee_certifications.rb
+++ b/spec/factories/referee_certifications.rb
@@ -24,5 +24,13 @@ FactoryBot.define do
     received_at { DateTime.now.utc }
     revoked_at nil
     renewed_at nil
+
+    trait :snitch do
+      certification { create :certification, :snitch }
+    end
+
+    trait :head do
+      certification { create :certification, :head }
+    end
   end
 end

--- a/spec/factories/referee_certifications.rb
+++ b/spec/factories/referee_certifications.rb
@@ -3,6 +3,7 @@
 # Table name: referee_certifications
 #
 #  id               :bigint(8)        not null, primary key
+#  needs_renewal_at :datetime
 #  received_at      :datetime
 #  renewed_at       :datetime
 #  revoked_at       :datetime

--- a/spec/models/referee_certification_spec.rb
+++ b/spec/models/referee_certification_spec.rb
@@ -3,6 +3,7 @@
 # Table name: referee_certifications
 #
 #  id               :bigint(8)        not null, primary key
+#  needs_renewal_at :datetime
 #  received_at      :datetime
 #  renewed_at       :datetime
 #  revoked_at       :datetime


### PR DESCRIPTION
This PR adds new functionality around renewing certifications. This allows refs that were previously certified under the old tests to re-certify. This also includes the removal of Switzerland as an old test exception.

New flow:
<img src='https://cl.ly/2e585b842d0b/Screen%252520Recording%2525202018-11-11%252520at%25252002.43%252520PM.gif' />