### PR TITLE
Revert server-side cooldown check

### DIFF
--- a/app/controllers/classmarker_controller.rb
+++ b/app/controllers/classmarker_controller.rb
@@ -42,10 +42,8 @@ class ClassmarkerController < ApplicationController
     referee = Referee.find_by(id: results_data['cm_user_id'])
     test_level = determine_level(test_data['test_name'])
 
-    if referee.present? && !in_cool_down_period?(referee, test_level)
-      create_test_attempt(test_level, referee)
-      create_test_results(results_data, test_level, referee)
-    end
+    create_test_attempt(test_level, referee) if referee.present?
+    create_test_results(results_data, test_level, referee) if referee.present?
   end
 
   def hmac_header_valid?


### PR DESCRIPTION
Classmarker webhooks fail. Probably because of the new server-side cooldown check. Reverting that part of the commit.