### PR TITLE
Test results bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem 'semantic-ui-sass'
 
 gem 'loofah', '>= 2.2.3'
 gem 'rack', '>= 2.0.6'
+gem 'barnes'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,9 @@ GEM
       io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
+    barnes (0.0.7)
+      multi_json (~> 1)
+      statsd-ruby (~> 1.1)
     bcrypt (3.1.12)
     bindex (0.5.0)
     bootsnap (1.3.1)
@@ -119,6 +122,7 @@ GEM
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     msgpack (1.2.4)
+    multi_json (1.13.1)
     nio4r (2.3.1)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
@@ -209,9 +213,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    selenium-webdriver (3.14.0)
+    selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
-      rubyzip (~> 1.2.2)
+      rubyzip (~> 1.2, >= 1.2.2)
     semantic-ui-sass (2.4.0.1)
       sass (>= 3.2)
     simplecov (0.16.1)
@@ -231,6 +235,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    statsd-ruby (1.4.0)
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -264,6 +269,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate
+  barnes
   bootsnap (>= 1.1.0)
   byebug
   capybara (>= 2.15, < 4.0)

--- a/app/javascript/packs/MainApp/components/CertificationContent.jsx
+++ b/app/javascript/packs/MainApp/components/CertificationContent.jsx
@@ -1,6 +1,11 @@
 import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
-import { Label, Message, Modal, Button, Popup } from 'semantic-ui-react'
+import {
+  Label,
+  Message,
+  Modal,
+  Button
+} from 'semantic-ui-react'
 import { capitalize } from 'lodash'
 import { DateTime } from 'luxon'
 import axios from 'axios'
@@ -287,9 +292,17 @@ class CertificationContent extends Component {
     return <ContentSegment segmentContent={segmentContent} headerContent={headerContent} />
   }
 
+  renderRenewalButton = () => (
+    <div style={{ flex: '1', display: 'flex', justifyContent: 'flex-end' }}>
+      <Button negative content="Renew Certifications" onClick={this.handleRenewalConfirmOpen} />
+    </div>
+  )
+
   renderCompletedCertifications = () => {
+    const { levelsThatNeedRenewal } = this.state
     const { refCertifications, isEditable } = this.props
 
+    const shouldShowRenewalButton = !(levelsThatNeedRenewal.length > 0)
     const headerContent = 'Completed Certifications'
     let segmentContent
 
@@ -299,13 +312,7 @@ class CertificationContent extends Component {
           <div style={{ flex: '1' }}>
             {refCertifications.map(this.renderCertification)}
           </div>
-          {
-            isEditable && (
-              <div style={{ flex: '1', display: 'flex', justifyContent: 'flex-end' }}>
-                <Button negative content="Renew Certifications" onClick={this.handleRenewalConfirmOpen} />
-              </div>
-            )
-          }
+          {isEditable && shouldShowRenewalButton && this.renderRenewalButton()}
         </div>
       )
     } else {

--- a/app/javascript/packs/MainApp/components/TestResultsTable.jsx
+++ b/app/javascript/packs/MainApp/components/TestResultsTable.jsx
@@ -1,7 +1,11 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { Table, Icon } from 'semantic-ui-react'
-import { capitalize } from 'lodash'
+import { capitalize, uniqueId } from 'lodash'
+
+function valueStringFormatter(value, modifier) {
+  return value ? `${value}${modifier}` : 'N/A'
+}
 
 class TestResultsTable extends Component {
   static propTypes ={
@@ -59,33 +63,31 @@ class TestResultsTable extends Component {
       pointsScored
     } = testResult
 
-    const totalDuration = duration || 'N/A' // TODO use timeFinished and timeStarted to determine duration if null
     const passedIcon = <Icon name="checkmark" color="green" size="large" />
     const failedIcon = <Icon name="times" color="red" size="large" />
-    const percentagePassed = percentage ? `${percentage}%` : 'N/A'
 
     return (
-      <Table.Row>
+      <Table.Row key={uniqueId(`${testLevel}_`)}>
         <Table.Cell>
           {capitalize(testLevel)}
         </Table.Cell>
         <Table.Cell>
-          {totalDuration}
+          {valueStringFormatter(duration, '')}
         </Table.Cell>
         <Table.Cell>
           {passed ? passedIcon : failedIcon}
         </Table.Cell>
         <Table.Cell>
-          {`${minimumPassPercentage}%`}
+          {valueStringFormatter(minimumPassPercentage, '%')}
         </Table.Cell>
         <Table.Cell>
-          {percentagePassed}
+          {valueStringFormatter(percentage, '%')}
         </Table.Cell>
         <Table.Cell>
-          {`${pointsScored} pts`}
+          {valueStringFormatter(pointsScored, ' pts')}
         </Table.Cell>
         <Table.Cell>
-          {`${pointsAvailable} pts`}
+          {valueStringFormatter(pointsAvailable, ' pts')}
         </Table.Cell>
       </Table.Row>
     )

--- a/app/serializers/referee_serializer.rb
+++ b/app/serializers/referee_serializer.rb
@@ -53,6 +53,6 @@ class RefereeSerializer
   has_many :national_governing_bodies, serializer: :national_governing_body
   has_many :referee_certifications, serializer: :referee_certification
   has_many :certifications, serializer: :certification
-  has_many :test_results, if: proc { |params| params[:include_tests] }
-  has_many :test_attempts, if: proc { |params| params[:include_tests] }
+  has_many :test_results, if: proc { |_referee, params| params[:include_tests] }
+  has_many :test_attempts, if: proc { |_referee, params| params[:include_tests] }
 end


### PR DESCRIPTION
A while back we added a param to not include test results in the index call. The thought was great but we introduced a bug that prevented *all* test results from being returned. This PR fixes that, along with  a couple of other UX issues in the test results table and the certifications tab on the profile.