### PR TITLE
Test taking frontend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ gem 'loofah', '>= 2.2.3'
 gem 'rack', '>= 2.0.6'
 gem 'barnes'
 gem 'sidekiq'
+gem 'sidekiq-status'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,8 @@ GEM
     chromedriver-helper (1.2.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    chronic_duration (0.10.6)
+      numerizer (~> 0.1.1)
     codecov (0.1.10)
       json
       simplecov
@@ -129,6 +131,7 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
+    numerizer (0.1.1)
     orm_adapter (0.5.0)
     parallel (1.12.1)
     parser (2.5.1.2)
@@ -229,6 +232,9 @@ GEM
       rack (>= 1.5.0)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 5)
+    sidekiq-status (1.1.2)
+      chronic_duration
+      sidekiq (>= 3.0)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -305,6 +311,7 @@ DEPENDENCIES
   selenium-webdriver
   semantic-ui-sass
   sidekiq
+  sidekiq-status
   spring
   spring-watcher-listen (~> 2.0.0)
   timecop

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,3 @@
 web: bundle exec rails server -p $PORT
-mailers: bundle exec sidekiq -c 2
-default: bundle exec sidekiq -c 2
+mailers: bundle exec sidekiq -v -c 5 -q mailers
 release: bundle exec rails db:migrate

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,4 @@
 web: bundle exec rails server -p $PORT
 mailers: bundle exec sidekiq -c 2
+default: bundle exec sidekiq -c 2
 release: bundle exec rails db:migrate

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
 web: bundle exec rails s
-mailers: bundle exec sidekiq -c 2 
+mailers: bundle exec sidekiq -c 2
+default: bundle exec sidekiq -c 2
 webpacker: ./bin/webpack-dev-server

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,3 @@
 web: bundle exec rails s
-mailers: bundle exec sidekiq -c 2
-default: bundle exec sidekiq -c 2
+mailers: bundle exec sidekiq -v -c 5 -q mailers
 webpacker: ./bin/webpack-dev-server

--- a/app/controllers/api/v1/answers_controller.rb
+++ b/app/controllers/api/v1/answers_controller.rb
@@ -10,7 +10,7 @@ module Api
       layout false
 
       def index
-        json_string = AnswerSerializer.new(answers).serialized_json
+        json_string = AnswerSerializer.new(answers, params: { include_correct: true }).serialized_json
 
         render json: json_string, status: :ok
       end
@@ -21,7 +21,7 @@ module Api
         answer.question_id = @question.id
         answer.save!
 
-        json_string = AnswerSerializer.new(answer).serialized_json
+        json_string = AnswerSerializer.new(answer, params: { include_correct: true }).serialized_json
 
         render json: json_string, status: :ok
       rescue => exception
@@ -30,7 +30,7 @@ module Api
       end
 
       def show
-        json_string = AnswerSerializer.new(@answer).serialized_json
+        json_string = AnswerSerializer.new(@answer, params: { include_correct: true }).serialized_json
 
         render json: json_string, status: :ok
       end
@@ -38,7 +38,7 @@ module Api
       def update
         @answer.update!(permitted_params)
 
-        json_string = AnswerSerializer.new(@answer).serialized_json
+        json_string = AnswerSerializer.new(@answer, params: { include_correct: true }).serialized_json
 
         render json: json_string, status: :ok
       rescue => exception
@@ -47,7 +47,7 @@ module Api
       end
 
       def destroy
-        json_string = AnswerSerializer.new(@answer).serialized_json
+        json_string = AnswerSerializer.new(@answer, params: { include_correct: true }).serialized_json
 
         @answer.destroy!
 

--- a/app/controllers/api/v1/tests_controller.rb
+++ b/app/controllers/api/v1/tests_controller.rb
@@ -64,7 +64,7 @@ module Api
       def start
         questions = @test.fetch_random_questions
 
-        json_string = QuestionSerializer.new(questions).serialized_json
+        json_string = QuestionSerializer.new(questions, include: %i[answers]).serialized_json
 
         render json: json_string, status: :ok
       rescue => exception

--- a/app/controllers/api/v1/tests_controller.rb
+++ b/app/controllers/api/v1/tests_controller.rb
@@ -13,7 +13,7 @@ module Api
         'This test is unavailable for you to take currently, please try again in a few hours'.freeze
 
       def index
-        @tests = Test.all
+        @tests = params[:active_only] ? Test.active : Test.all
 
         json_string = TestSerializer.new(@tests).serialized_json
 

--- a/app/controllers/api/v1/tests_controller.rb
+++ b/app/controllers/api/v1/tests_controller.rb
@@ -11,7 +11,7 @@ module Api
       layout false
 
       INVALID_TEST_ATTEMPT =
-        'This test is unavailable for you to take currently, please try again in '.freeze
+        'This test is unavailable for you to take currently, please try again in'.freeze
 
       INVALID_TRY_COUNT = 'This test is no longer available to you due to hitting the maximum amount of tries'.freeze
 

--- a/app/javascript/packs/MainApp/components/Answer.jsx
+++ b/app/javascript/packs/MainApp/components/Answer.jsx
@@ -7,6 +7,24 @@ import { isEmpty } from 'lodash'
 import RichTextEditor from './RichTextEditor'
 
 class Answer extends Component {
+  static propTypes = {
+    values: PropTypes.shape({
+      description: PropTypes.string,
+      id: PropTypes.string
+    }).isRequired,
+    isCorrect: PropTypes.bool.isRequired,
+    onSave: PropTypes.func,
+    onCorrectChange: PropTypes.func.isRequired,
+    onDelete: PropTypes.func,
+    isEditable: PropTypes.bool
+  }
+
+  static defaultProps = {
+    isEditable: true,
+    onSave: () => {},
+    onDelete: () => {}
+  }
+
   state = {
     updatedDescription: '',
     updatedCorrect: false,
@@ -27,10 +45,10 @@ class Answer extends Component {
   handleDescriptionChange = (_e, { value }) => this.setState({ updatedDescription: value })
 
   handleCorrectChange = () => {
-    const { onCorrectChange, values: { id } } = this.props
+    const { onCorrectChange, values: { id }, isEditable } = this.props
 
-    this.setState({ updatedCorrect: true })
-    if (onCorrectChange) onCorrectChange(id)
+    if (isEditable) this.setState({ updatedCorrect: true })
+    onCorrectChange(id)
   }
 
   handleSave = () => {
@@ -69,8 +87,9 @@ class Answer extends Component {
 
   renderAnswer = () => {
     const { isEditing } = this.state
+    const { isEditable } = this.props
 
-    const input = <RichTextEditor value={this.descriptionValue} onChange={this.handleDescriptionChange} />
+    const input = isEditable && <RichTextEditor value={this.descriptionValue} onChange={this.handleDescriptionChange} />
     // eslint-disable-next-line react/no-danger
     const renderedText = <div dangerouslySetInnerHTML={{ __html: this.descriptionValue }} />
 
@@ -82,34 +101,24 @@ class Answer extends Component {
   }
 
   render() {
-    const { isCorrect } = this.props
+    const { isCorrect, isEditable } = this.props
     const { isEditing } = this.state
+    const isDisabled = !isEditable ? false : !isEditing
 
     return (
       <div style={{ display: 'flex', alignItems: 'center', margin: '15px 0' }}>
         <Form.Field
           className="answer-checkbox"
           control={Checkbox}
-          disabled={!isEditing}
+          disabled={isDisabled}
           checked={isCorrect}
           onClick={this.handleCorrectChange}
         />
         {this.renderAnswer()}
-        {this.renderButtons()}
+        {isEditable && this.renderButtons()}
       </div>
     )
   }
-}
-
-Answer.propTypes = {
-  values: PropTypes.shape({
-    description: PropTypes.string,
-    id: PropTypes.string
-  }).isRequired,
-  isCorrect: PropTypes.bool.isRequired,
-  onSave: PropTypes.func.isRequired,
-  onCorrectChange: PropTypes.func.isRequired,
-  onDelete: PropTypes.func.isRequired
 }
 
 export default Answer

--- a/app/javascript/packs/MainApp/components/AnswerManager.jsx
+++ b/app/javascript/packs/MainApp/components/AnswerManager.jsx
@@ -8,14 +8,15 @@ import Answer from './Answer'
 const emptyAnswer = index => (
   {
     id: `${String(null)}-${index}`,
-    description: ''
+    description: '',
+    correct: false
   }
 )
 
 const sanitizeAnswer = (answer, index) => {
-  const { id, attributes: { description } } = answer
+  const { id, attributes: { description, correct } } = answer
 
-  return { id: `${String(id)}-${index}`, description }
+  return { id: `${String(id)}-${index}`, description, correct }
 }
 
 const findAnswer = id => answer => answer.id === id

--- a/app/javascript/packs/MainApp/components/AnswerManager.jsx
+++ b/app/javascript/packs/MainApp/components/AnswerManager.jsx
@@ -8,19 +8,14 @@ import Answer from './Answer'
 const emptyAnswer = index => (
   {
     id: `${String(null)}-${index}`,
-    description: '',
-    correct: false
+    description: ''
   }
 )
 
 const sanitizeAnswer = (answer, index) => {
-  const { id, attributes: { description, correct } } = answer
+  const { id, attributes: { description } } = answer
 
-  return {
-    id: `${String(id)}-${index}`,
-    description,
-    correct
-  }
+  return { id: `${String(id)}-${index}`, description }
 }
 
 const findAnswer = id => answer => answer.id === id

--- a/app/javascript/packs/MainApp/components/CertificationLinks.jsx
+++ b/app/javascript/packs/MainApp/components/CertificationLinks.jsx
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import axios from 'axios'
-import { capitalize } from 'lodash'
+import { capitalize, groupBy } from 'lodash'
 import { DateTime } from 'luxon'
 import { Segment, Label, Message } from 'semantic-ui-react'
 
@@ -77,7 +77,10 @@ class CertificationLinks extends Component {
   get certificationConfig() {
     const { testLinks } = this.state
 
-    if (NEW_TESTS_ENABLED) return testLinks
+    if (NEW_TESTS_ENABLED) {
+      const groupedLinks = groupBy(testLinks, 'language')
+      return groupedLinks
+    }
 
     return CERT_LINKS(this.canTakeSnitchTest(), this.canTakeAssistantTest(), this.canTakeHeadTest())
   }
@@ -96,11 +99,12 @@ class CertificationLinks extends Component {
   }
 
   buildTestLink = ({ id, attributes }) => {
+    const { refereeId } = this.props
     const color = testColor(attributes.test_level)
     const enabled = this.isTestEnabled(attributes.test_level)
 
     return {
-      link: `/tests/${id}`,
+      link: `/referees/${refereeId}/tests/${id}`,
       title: attributes.name,
       language: attributes.language,
       color,

--- a/app/javascript/packs/MainApp/components/CertificationLinks.jsx
+++ b/app/javascript/packs/MainApp/components/CertificationLinks.jsx
@@ -21,6 +21,8 @@ const testColor = (testLevel) => {
   }
 }
 
+const allLinksDisabled = linkArray => linkArray.filter(link => link.enabled).length === 0
+
 class CertificationLinks extends Component {
   static propTypes = {
     hasPaid: PropTypes.bool.isRequired,
@@ -100,8 +102,8 @@ class CertificationLinks extends Component {
 
   buildTestLink = ({ id, attributes }) => {
     const { refereeId } = this.props
-    const color = testColor(attributes.test_level)
-    const enabled = this.isTestEnabled(attributes.test_level)
+    const color = testColor(attributes.level)
+    const enabled = this.isTestEnabled(attributes.level)
 
     return {
       link: `/referees/${refereeId}/tests/${id}`,
@@ -191,12 +193,16 @@ class CertificationLinks extends Component {
     return <Label {...labelProps} />
   }
 
-  renderLanguageSection = section => (
-    <Segment padded key={section[0]}>
-      <Label attached="top">{capitalize(section[0])}</Label>
-      {section[1].map(this.renderLink)}
-    </Segment>
-  )
+  renderLanguageSection = (section) => {
+    if (allLinksDisabled(section[1])) return null
+
+    return (
+      <Segment padded key={section[0]}>
+        <Label attached="top">{capitalize(section[0])}</Label>
+        {section[1].map(this.renderLink)}
+      </Segment>
+    )
+  }
 
   renderTests = () => (
     <Fragment>

--- a/app/javascript/packs/MainApp/components/CertificationLinks.jsx
+++ b/app/javascript/packs/MainApp/components/CertificationLinks.jsx
@@ -1,0 +1,232 @@
+import React, { Component, Fragment } from 'react'
+import PropTypes from 'prop-types'
+import axios from 'axios'
+import { capitalize } from 'lodash'
+import { DateTime } from 'luxon'
+import { Segment, Label, Message } from 'semantic-ui-react'
+
+import ContentSegment from './ContentSegment'
+import { CERT_LINKS, NEW_TESTS_ENABLED } from '../constants'
+
+const testColor = (testLevel) => {
+  switch (testLevel) {
+    case 'snitch':
+      return 'yellow'
+    case 'assistant':
+      return 'blue'
+    case 'head':
+      return 'green'
+    default:
+      return 'blue'
+  }
+}
+
+class CertificationLinks extends Component {
+  static propTypes = {
+    hasPaid: PropTypes.bool.isRequired,
+    refereeId: PropTypes.string.isRequired,
+    refCertifications: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.string,
+        level: PropTypes.string
+      })
+    ).isRequired,
+    levelsThatNeedRenewal: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.string,
+        level: PropTypes.string,
+      })
+    ).isRequired,
+    testAttempts: PropTypes.arrayOf(
+      PropTypes.shape({
+        next_attempt_at: PropTypes.string,
+        test_level: PropTypes.string
+      })
+    ).isRequired,
+    onRouteChange: PropTypes.func.isRequired,
+  }
+
+  state = {
+    testLinks: []
+  }
+
+  componentDidMount() {
+    if (NEW_TESTS_ENABLED) {
+      axios.get('/api/v1/tests', { active_only: true })
+        .then(({ data }) => {
+          const { data: testData } = data
+
+          const testLinks = testData.map(this.buildTestLink)
+          this.setState({ testLinks })
+        })
+    }
+  }
+
+  get hasSnitchCert() {
+    return this.hasPassedTest('snitch')
+  }
+
+  get hasAssistantCert() {
+    return this.hasPassedTest('assistant')
+  }
+
+  get hasHeadCert() {
+    return this.hasPassedTest('head')
+  }
+
+  get certificationConfig() {
+    const { testLinks } = this.state
+
+    if (NEW_TESTS_ENABLED) return testLinks
+
+    return CERT_LINKS(this.canTakeSnitchTest(), this.canTakeAssistantTest(), this.canTakeHeadTest())
+  }
+
+  isTestEnabled = (testLevel) => {
+    switch (testLevel) {
+      case 'snitch':
+        return this.canTakeSnitchTest()
+      case 'assistant':
+        return this.canTakeAssistantTest()
+      case 'head':
+        return this.canTakeHeadTest()
+      default:
+        return true
+    }
+  }
+
+  buildTestLink = ({ id, attributes }) => {
+    const color = testColor(attributes.test_level)
+    const enabled = this.isTestEnabled(attributes.test_level)
+
+    return {
+      link: `/tests/${id}`,
+      title: attributes.name,
+      language: attributes.language,
+      color,
+      enabled
+    }
+  }
+
+  canTakeSnitchTest = () => {
+    const { levelsThatNeedRenewal } = this.props
+    if (this.isInCoolDownPeriod('snitch')) return false
+    if (levelsThatNeedRenewal.find(refCert => refCert.level === 'snitch')) return true
+
+    return !this.hasSnitchCert && !this.hasHeadCert
+  }
+
+  canTakeAssistantTest = () => {
+    const { levelsThatNeedRenewal } = this.props
+    if (this.isInCoolDownPeriod('assistant')) return false
+    if (levelsThatNeedRenewal.find(refCert => refCert.level === 'assistant')) return true
+
+    return !this.hasAssistantCert && !this.hasHeadCert
+  }
+
+  canTakeHeadTest = (hasPaid) => {
+    const { levelsThatNeedRenewal } = this.props
+    if (!hasPaid) return false
+    if (this.isInCoolDownPeriod('head')) return false
+    if (levelsThatNeedRenewal.find(refCert => refCert.level === 'head')) return true
+
+    return this.hasSnitchCert && this.hasAssistantCert
+  }
+
+  hasPassedTest = (level) => {
+    const { refCertifications, levelsThatNeedRenewal } = this.props
+    const passedCert = refCertifications.some(({ level: certificationLevel }) => certificationLevel === level)
+    const levelNeedsRenewal = levelsThatNeedRenewal.find(details => details.level === level)
+
+    if (levelNeedsRenewal) return false
+    return passedCert
+  }
+
+  isInCoolDownPeriod = (certType) => {
+    const { testAttempts } = this.props
+    const matchingTestAttempt = testAttempts.filter(testAttempt => testAttempt.test_level === certType)
+
+    if (matchingTestAttempt.length > 0) {
+      const rawAttemptString = matchingTestAttempt[0].next_attempt_at.slice(0, -3).trim()
+      const nextAttemptAt = DateTime.fromSQL(rawAttemptString)
+      const currentTime = DateTime.local()
+
+      return !(nextAttemptAt < currentTime)
+    }
+
+    return false
+  }
+
+  handleTestClick = link => () => {
+    const { onRouteChange } = this.props
+
+    onRouteChange(link)
+  }
+
+  renderLink = (test) => {
+    const {
+      link, title, enabled, color
+    } = test
+    const { refereeId } = this.props
+    if (!enabled) return null
+
+    // if link matches classmarker treat as href, otherwise push to test start route
+    const isClassmarker = /classmarker/.test(link)
+    const labelProps = {
+      key: title,
+      size: 'big',
+      as: isClassmarker ? 'a' : 'button',
+      href: isClassmarker ? `${link}&cm_user_id=${refereeId}` : null,
+      onClick: isClassmarker ? null : this.handleTestClick(link),
+      target: isClassmarker ? '_blank' : null,
+      rel: isClassmarker ? 'noopener noreferrer' : null,
+      content: title,
+      color,
+    }
+
+    return <Label {...labelProps} />
+  }
+
+  renderLanguageSection = section => (
+    <Segment padded key={section[0]}>
+      <Label attached="top">{capitalize(section[0])}</Label>
+      {section[1].map(this.renderLink)}
+    </Segment>
+  )
+
+  renderTests = () => (
+    <Fragment>
+      {Object.entries(this.certificationConfig).map(this.renderLanguageSection)}
+      <Message info>
+        Please note that you have to wait 24 hours after a failed test to be allowed to retry (72 hours for the head
+        referee test), even if the link is still visible. Every passed and failed test attempt will be recorded,
+        even if the testing tool fails to properly report the attempt back to us on time. In rare cases this may
+        take up to 72 hours. Our apologies if this happens.
+      </Message>
+    </Fragment>
+  )
+
+  renderCoolDownNotice = () => (
+    <p>
+      One or more tests are unavailable at the moment, please check back after the 24 hour
+      (for Snitch and Assistant) or 72 hour (for Head) cool down period.
+    </p>
+  )
+
+  render() {
+    const { hasPaid } = this.props
+    if (this.hasHeadCert) return null
+    const canTakeSnitch = this.canTakeSnitchTest()
+    const canTakeAssistant = this.canTakeAssistantTest()
+    const canTakeHead = this.canTakeHeadTest(hasPaid)
+
+    const anyTestsAvailable = [canTakeSnitch, canTakeAssistant, canTakeHead].some(testStatus => testStatus)
+
+    const headerContent = 'Available Written Tests'
+    const segmentContent = anyTestsAvailable ? this.renderTests() : this.renderCoolDownNotice()
+
+    return <ContentSegment segmentContent={segmentContent} headerContent={headerContent} />
+  }
+}
+
+export default CertificationLinks

--- a/app/javascript/packs/MainApp/components/Counter.jsx
+++ b/app/javascript/packs/MainApp/components/Counter.jsx
@@ -1,0 +1,59 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import { Header } from 'semantic-ui-react'
+
+const formatTime = time => (time < 10 ? `0${time}` : time)
+
+const getDisplayColor = (limit, minutes) => {
+  const goodLimit = limit - Math.round(limit * 0.3)
+
+  if (minutes < goodLimit) return 'grey'
+  if (minutes < limit) return 'yellow'
+  if (minutes >= limit) return 'red'
+
+  return 'grey'
+}
+
+class Counter extends Component {
+  static propTypes = {
+    timeLimit: PropTypes.number.isRequired
+  }
+
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      minutes: 0,
+      seconds: 0
+    }
+
+    this.startCounter()
+  }
+
+  startCounter = () => {
+    setInterval(this.handleTick, 1000)
+  }
+
+  handleTick = () => {
+    const { seconds } = this.state
+
+    if (seconds < 59) {
+      this.setState(prevState => ({ seconds: prevState.seconds + 1 }))
+    } else {
+      this.setState(prevState => ({ minutes: prevState.minutes + 1, seconds: 0 }))
+    }
+  }
+
+  render() {
+    const { minutes, seconds } = this.state
+    const { timeLimit } = this.props
+    const displayMinute = formatTime(minutes)
+    const displaySecond = formatTime(seconds)
+
+    return (
+      <Header as="h3" color={getDisplayColor(timeLimit, minutes)}>{`${displayMinute}:${displaySecond}`}</Header>
+    )
+  }
+}
+
+export default Counter

--- a/app/javascript/packs/MainApp/components/RefereeProfile.jsx
+++ b/app/javascript/packs/MainApp/components/RefereeProfile.jsx
@@ -9,12 +9,13 @@ import RefereeProfileEdit from './RefereeProfileEdit'
 import ProfileContent from './ProfileContent'
 import CertificationContent from './CertificationContent'
 
-const NGBS_WITH_OLD_TEST_REQUIREMENT = ['Peru']
-
 class RefereeProfile extends Component {
   static propTypes = {
     match: PropTypes.shape({
       params: PropTypes.object
+    }).isRequired,
+    history: PropTypes.shape({
+      push: PropTypes.func
     }).isRequired
   }
 
@@ -134,6 +135,12 @@ class RefereeProfile extends Component {
       httpStatus: status,
       httpStatusText: statusText
     })
+  }
+
+  handleRouteChange = (newRoute) => {
+    const { history } = this.props
+
+    history.push(newRoute)
   }
 
   handleSubmit = () => {
@@ -259,19 +266,16 @@ class RefereeProfile extends Component {
   renderCertificationContent = () => {
     const {
       referee: {
-        certifications, isEditable, submittedPaymentAt, nationalGoverningBodies, testResults, testAttempts
+        certifications, isEditable, submittedPaymentAt, testResults, testAttempts
       }
     } = this.state
     const { match: { params } } = this.props
-
-    const shouldTakeOldTests = nationalGoverningBodies.some(ngb => NGBS_WITH_OLD_TEST_REQUIREMENT.includes(ngb.name))
 
     return (
       <Tab.Pane>
         <CertificationContent
           refereeId={params.id}
           isEditable={isEditable}
-          shouldTakeOldTests={shouldTakeOldTests}
           hasPaid={!!submittedPaymentAt}
           testResults={testResults}
           testAttempts={testAttempts}
@@ -279,6 +283,7 @@ class RefereeProfile extends Component {
           onSuccess={this.handlePaymentSuccess}
           onError={this.handlePaymentError}
           onCancel={this.handlePaymentCancel}
+          onRouteChange={this.handleRouteChange}
         />
       </Tab.Pane>
     )

--- a/app/javascript/packs/MainApp/components/StartTest.jsx
+++ b/app/javascript/packs/MainApp/components/StartTest.jsx
@@ -245,10 +245,11 @@ class StartTest extends Component {
   }
 
   renderTest = () => {
-    const { testQuestions, currentQuestionIndex } = this.state
+    const { testQuestions, currentQuestionIndex, timeLimit } = this.state
 
     return (
       <TestTaker
+        timeLimit={timeLimit}
         currentQuestion={testQuestions[currentQuestionIndex]}
         onAnswerSelect={this.handleAnswerSelect}
       />

--- a/app/javascript/packs/MainApp/components/StartTest.jsx
+++ b/app/javascript/packs/MainApp/components/StartTest.jsx
@@ -1,0 +1,284 @@
+import React, { Component, Fragment } from 'react'
+import PropTypes from 'prop-types'
+import axios from 'axios'
+import { shuffle } from 'lodash'
+import { DateTime } from 'luxon'
+import {
+  Segment, Header, Message, Icon, Divider, Button
+} from 'semantic-ui-react'
+
+import TestTaker from './TestTaker'
+
+const formatAnswer = ({ id, attributes }) => ({
+  id,
+  description: attributes.description,
+  selected: false
+})
+
+const formatQuestions = (questions, allAnswers) => (
+  questions.reduce((accObj, question, index) => {
+    const questionAnswers = allAnswers.filter(({ attributes }) => String(attributes.question_id) === question.id)
+    const formattedAnswers = questionAnswers.map(formatAnswer)
+    // eslint-disable-next-line no-param-reassign
+    accObj[index] = {
+      questionId: question.id,
+      description: question.attributes.description,
+      answers: shuffle(formattedAnswers)
+    }
+    return accObj
+  }, [])
+)
+
+const buildRefereeAnswers = testQuestions => (
+  testQuestions.map((question) => {
+    const selectedAnswerId = question.answers.find(answer => !!answer.selected).id
+    return {
+      question_id: question.id,
+      answer_id: selectedAnswerId
+    }
+  })
+)
+
+class StartTest extends Component {
+  static propTypes = {
+    match: PropTypes.shape({
+      params: PropTypes.object
+    }).isRequired,
+    history: PropTypes.shape({
+      push: PropTypes.func
+    }).isRequired
+  }
+
+  state = {
+    status: 0,
+    statusText: '',
+    name: '',
+    description: '',
+    timeLimit: 0,
+    testStarted: false,
+    testFinished: false,
+    testQuestions: {},
+    currentQuestionIndex: 0
+  }
+
+  componentDidMount() {
+    const { match: { params } } = this.props
+
+    axios.get(`/api/v1/tests/${params.testId}`)
+      .then(({ data, status, statusText }) => {
+        const { data: { attributes } } = data
+
+        const testData = {
+          name: attributes.name,
+          description: attributes.description,
+          timeLimit: attributes.time_limit
+        }
+        this.setState({ status, statusText, ...testData })
+      })
+  }
+
+  get isLastQuestion() {
+    const { currentQuestionIndex, testQuestions } = this.state
+
+    return currentQuestionIndex === testQuestions.length - 1
+  }
+
+  get currentQuestion() {
+    const { currentQuestionIndex, testQuestions } = this.state
+
+    return testQuestions[currentQuestionIndex]
+  }
+
+  get isFirstQuestion() {
+    const { currentQuestionIndex } = this.state
+
+    return currentQuestionIndex === 0
+  }
+
+  handleQuestionChange = action => () => {
+    switch (action) {
+      case 'prev':
+        this.setState(prevState => ({ currentQuestionIndex: prevState.currentQuestionIndex - 1 }))
+        break
+      case 'next':
+        this.handleFetchNextQuestion()
+        break
+      default:
+        this.handleFetchNextQuestion()
+        break
+    }
+  }
+
+  handleAnswerSelect = (answerId) => {
+    // const { currentQuestionIndex, testQuestions } = this.state
+
+    const currentAnswers = this.currentQuestion.answers
+
+    const selectedAnswerIndex = currentAnswers.indexOf(answer => answer.id === answerId)
+    const selectedAnswer = currentAnswers[selectedAnswerIndex]
+    const updatedAnswer = { ...selectedAnswer, selected: true }
+
+    currentAnswers.splice(selectedAnswerIndex, 1, updatedAnswer)
+    // console.log(this.currentQuestion)
+    // const newQuestions = testQuestions[currentQuestionIndex].splice(sel)
+  }
+
+  handleFetchNextQuestion = () => {
+    const { currentQuestionIndex } = this.state
+    let nextIndex = currentQuestionIndex + 1
+
+    if (this.isLastQuestion) {
+      this.handleFinishTest()
+      nextIndex = 0
+    }
+
+    this.setState({ currentQuestionIndex: nextIndex })
+  }
+
+  handleGoBackToProfile = () => {
+    const { match: { params }, history: { push } } = this.props
+
+    push(`/referees/${params.refereeId}`)
+  }
+
+  handleFinishTest = () => {
+    const { testQuestions, startedAt } = this.state
+    const { match: { params } } = this.props
+    const finishedAt = DateTime.local()
+    const refereeAnswers = buildRefereeAnswers(testQuestions)
+
+    const postParams = {
+      started_at: startedAt,
+      finished_at: finishedAt,
+      referee_answers: refereeAnswers
+    }
+
+    axios.post(`/api/v1/tests/${params.testId}/finish`, postParams)
+      .then(() => this.setState({ testQuestions: {}, testFinished: true }))
+      .catch((error) => {
+        const { status, statusText } = error.response || {
+          status: 500,
+          statusText: 'Error'
+        }
+
+        this.setState({ status, statusText })
+      })
+  }
+
+  handleStartTest = () => {
+    const { match: { params } } = this.props
+
+    axios.get(`/api/v1/tests/${params.testId}/start`)
+      .then(({ data }) => {
+        const { data: questions, included } = data
+
+        const testQuestions = formatQuestions(questions, included)
+        const startedAt = DateTime.local()
+        this.setState({ testQuestions, testStarted: true, startedAt })
+      })
+      .catch((error) => {
+        const { status, statusText } = error.response || {
+          status: 500,
+          statusText: 'Error'
+        }
+
+        this.setState({ status, statusText, testQuestions: {} })
+      })
+  }
+
+  renderButtons = () => {
+    const { testStarted } = this.state
+    const nextContent = this.isLastQuestion ? 'Finish' : 'Next'
+
+    return (
+      <Fragment>
+        {!testStarted && <Button color="blue" onClick={this.handleGoBackToProfile} content="Go Back to Profile" />}
+        {!testStarted && <Button color="green" onClick={this.handleStartTest} content="Start Test" />}
+        {
+          testStarted
+          && !this.isFirstQuestion
+          && <Button onClick={this.handleQuestionChange('prev')} content="Previous" />
+        }
+        {testStarted && <Button color="blue" onClick={this.handleQuestionChange('next')} content={nextContent} />}
+      </Fragment>
+    )
+  }
+
+  renderTestStartContent = () => {
+    const { name, description, timeLimit } = this.state
+    return (
+      <Fragment>
+        <Header as="h1" icon>
+          <Icon name="edit" />
+          {name}
+          <Header.Subheader>{description}</Header.Subheader>
+        </Header>
+        <Divider />
+        <Header as="h4">{`You will have ${timeLimit} minutes to complete this test.`}</Header>
+        <Header as="h4">Once you begin you may not exit the test.</Header>
+        <Header as="h4">
+          If you need more time to complete this test due to documented test taking challenges please contact
+          <a href="mailto:referees@iqasport.org"> referees@iqasport.org</a>
+        </Header>
+      </Fragment>
+    )
+  }
+
+  renderTestFinishContent = () => {
+    const { name, description } = this.state
+
+    return (
+      <Fragment>
+        <Header as="h1" icon>
+          <Icon name="checkmark box" />
+          {name}
+          <Header.Subheader>{description}</Header.Subheader>
+        </Header>
+        <Divider />
+        <Header as="h4">
+          We have successfully accepted your answers for this test.
+        </Header>
+        <Header as="h4">Results will be emailed to you through the email you registered your account with.</Header>
+        <Header as="h4">
+          If you do not see the results for this test attempt after an hour please reach out to
+          <a href="mailto:tech@iqasport.org"> tech@iqasport.org</a>
+        </Header>
+      </Fragment>
+    )
+  }
+
+  renderTest = () => {
+    const { testQuestions, currentQuestionIndex } = this.state
+
+    return (
+      <TestTaker
+        currentQuestion={testQuestions[currentQuestionIndex]}
+        onAnswerSelect={this.handleAnswerSelect}
+      />
+    )
+  }
+
+  renderMainContent = () => {
+    const { testStarted, testFinished } = this.state
+
+    if (testFinished) return this.renderTestFinishContent()
+    if (testStarted) return this.renderTest()
+
+    return this.renderTestStartContent()
+  }
+
+  render() {
+    const { status, statusText, testStarted } = this.state
+    const isError = status >= 400
+
+    return (
+      <Segment textAlign="center">
+        {isError && <Message error header={status} content={statusText} />}
+        {testStarted ? this.renderTest() : this.renderTestStartContent()}
+        {this.renderButtons()}
+      </Segment>
+    )
+  }
+}
+
+export default StartTest

--- a/app/javascript/packs/MainApp/components/StartTest.jsx
+++ b/app/javascript/packs/MainApp/components/StartTest.jsx
@@ -274,7 +274,7 @@ class StartTest extends Component {
     return (
       <Segment textAlign="center">
         {isError && <Message error header={status} content={statusText} />}
-        {testStarted ? this.renderTest() : this.renderTestStartContent()}
+        {this.renderMainContent()}
         {this.renderButtons()}
       </Segment>
     )

--- a/app/javascript/packs/MainApp/components/TestTaker.jsx
+++ b/app/javascript/packs/MainApp/components/TestTaker.jsx
@@ -1,5 +1,9 @@
+/* eslint-disable react/no-danger */
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import { Divider } from 'semantic-ui-react'
+
+import Answer from './Answer'
 
 class TestTaker extends Component {
   static propTypes = {
@@ -9,24 +13,50 @@ class TestTaker extends Component {
       answers: PropTypes.arrayOf(
         PropTypes.shape({
           id: PropTypes.string,
-          description: PropTypes.string,
-          selected: PropTypes.bool
+          description: PropTypes.string
         })
-      )
-    }).isRequired
+      ),
+      selectedAnswer: PropTypes.string
+    }).isRequired,
+    onAnswerSelect: PropTypes.func.isRequired
   }
 
   state = {}
+
+  handleAnswerChange = (answerId) => {
+    const { onAnswerSelect } = this.props
+
+    onAnswerSelect(answerId)
+  }
+
+  renderAnswer = (answer) => {
+    const { currentQuestion: { selectedAnswer } } = this.props
+    const isSelected = selectedAnswer === answer.id
+
+    return (
+      <Answer
+        key={answer.id}
+        isCorrect={isSelected}
+        onCorrectChange={this.handleAnswerChange}
+        isEditable={false}
+        values={{
+          id: answer.id,
+          description: answer.description
+        }}
+      />
+    )
+  }
 
   render() {
     const { currentQuestion } = this.props
 
     return (
       <div>
-        {currentQuestion.description}
-        <ul>
-          {currentQuestion.answers.map(answer => <li key={answer.id}>{answer.description}</li>)}
-        </ul>
+        <div dangerouslySetInnerHTML={{ __html: currentQuestion.description }} />
+        <Divider />
+        <div style={{ width: '50%', margin: '0 auto' }}>
+          {currentQuestion.answers.map(this.renderAnswer)}
+        </div>
       </div>
     )
   }

--- a/app/javascript/packs/MainApp/components/TestTaker.jsx
+++ b/app/javascript/packs/MainApp/components/TestTaker.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import { Divider } from 'semantic-ui-react'
 
 import Answer from './Answer'
+import Counter from './Counter'
 
 class TestTaker extends Component {
   static propTypes = {
@@ -18,10 +19,9 @@ class TestTaker extends Component {
       ),
       selectedAnswer: PropTypes.string
     }).isRequired,
-    onAnswerSelect: PropTypes.func.isRequired
+    onAnswerSelect: PropTypes.func.isRequired,
+    timeLimit: PropTypes.number.isRequired
   }
-
-  state = {}
 
   handleAnswerChange = (answerId) => {
     const { onAnswerSelect } = this.props
@@ -48,10 +48,11 @@ class TestTaker extends Component {
   }
 
   render() {
-    const { currentQuestion } = this.props
+    const { currentQuestion, timeLimit } = this.props
 
     return (
       <div>
+        <Counter timeLimit={timeLimit} />
         <div dangerouslySetInnerHTML={{ __html: currentQuestion.description }} />
         <Divider />
         <div style={{ width: '50%', margin: '0 auto' }}>

--- a/app/javascript/packs/MainApp/components/TestTaker.jsx
+++ b/app/javascript/packs/MainApp/components/TestTaker.jsx
@@ -1,0 +1,35 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+
+class TestTaker extends Component {
+  static propTypes = {
+    currentQuestion: PropTypes.shape({
+      id: PropTypes.string,
+      description: PropTypes.string,
+      answers: PropTypes.arrayOf(
+        PropTypes.shape({
+          id: PropTypes.string,
+          description: PropTypes.string,
+          selected: PropTypes.bool
+        })
+      )
+    }).isRequired
+  }
+
+  state = {}
+
+  render() {
+    const { currentQuestion } = this.props
+
+    return (
+      <div>
+        {currentQuestion.description}
+        <ul>
+          {currentQuestion.answers.map(answer => <li key={answer.id}>{answer.description}</li>)}
+        </ul>
+      </div>
+    )
+  }
+}
+
+export default TestTaker

--- a/app/javascript/packs/MainApp/constants.js
+++ b/app/javascript/packs/MainApp/constants.js
@@ -126,3 +126,93 @@ export const TEST_FORM_CONFIG = (values) => {
     },
   ]
 }
+
+export const CERT_LINKS = (snitchAvailable, assAvailable, headAvailable) => ({
+  english: [
+    {
+      title: 'Snitch Referee Written Test 2018–20',
+      link: 'https://www.classmarker.com/online-test/start/?quiz=4q95bafa6c1b2a6a',
+      color: 'yellow',
+      enabled: snitchAvailable
+    },
+    {
+      title: 'Assistant Referee Written Test 2018–20',
+      link: 'https://www.classmarker.com/online-test/start/?quiz=gyv5babf1bd8146f',
+      color: 'blue',
+      enabled: assAvailable
+    },
+    {
+      title: 'Head Referee Written Test 2018–20',
+      link: 'https://www.classmarker.com/online-test/start/?quiz=tyg5baff2b2c128c',
+      color: 'green',
+      enabled: headAvailable
+    },
+
+  ],
+  català: [
+    {
+      title: 'Examen escrit d’àrbitre/a d’esnitx 2018–20',
+      link: 'https://www.classmarker.com/online-test/start/?quiz=x6r5c759d0fa5e30',
+      color: 'yellow',
+      enabled: snitchAvailable
+    },
+    {
+      title: 'Examen escrit d’àrbitre/a assistent 2018–20',
+      link: 'https://www.classmarker.com/online-test/start/?quiz=6e45c75953075a03',
+      color: 'blue',
+      enabled: assAvailable
+    },
+    {
+      title: 'Examen escrit d’àrbitre/a principal 2018–20',
+      link: 'https://www.classmarker.com/online-test/start/?quiz=age5ca75fca28524',
+      color: 'green',
+      enabled: headAvailable
+    }
+  ],
+  français: [
+    {
+      title: 'Test écrit d’arbitre de vif d’or 2018–20',
+      link: 'https://www.classmarker.com/online-test/start/?quiz=g6e5c759e2b640cb',
+      color: 'yellow',
+      enabled: snitchAvailable
+    },
+    {
+      title: 'Test écrit d’arbitre assistant 2018–20',
+      link: 'https://www.classmarker.com/online-test/start/?quiz=ddq5c759def81996',
+      color: 'blue',
+      enabled: assAvailable
+    },
+    {
+      title: 'Test écrit d’arbitre principal 2018–20',
+      link: 'https://www.classmarker.com/online-test/start/?quiz=9qy5ca75f0501760',
+      color: 'green',
+      enabled: headAvailable
+    }
+  ]
+})
+
+export const OLD_CERT_LINKS = {
+  snitch: {
+    title: 'Snitch Referee Written Test 2016-18',
+    links: {
+      en: 'https://www.classmarker.com/online-test/start/?quiz=crx5bb21de04a997'
+    },
+    color: 'yellow'
+  },
+  assistant: {
+    title: 'Assistant Referee Written Test 2016-18',
+    links: {
+      en: 'https://www.classmarker.com/online-test/start/?quiz=tgr5bb21e1c149dc'
+    },
+    color: 'blue'
+  },
+  head: {
+    title: 'Head Referee Written Test 2016-18',
+    links: {
+      en: 'https://www.classmarker.com/online-test/start/?quiz=9xb5bb21e53ea15f'
+    },
+    color: 'green'
+  }
+}
+
+export const NEW_TESTS_ENABLED = !!process.env.TEST_TAKING_ENABLED

--- a/app/javascript/packs/MainApp/constants.js
+++ b/app/javascript/packs/MainApp/constants.js
@@ -215,4 +215,4 @@ export const OLD_CERT_LINKS = {
   }
 }
 
-export const NEW_TESTS_ENABLED = true // !!process.env.TEST_TAKING_ENABLED
+export const NEW_TESTS_ENABLED = !!process.env.TEST_TAKING_ENABLED

--- a/app/javascript/packs/MainApp/constants.js
+++ b/app/javascript/packs/MainApp/constants.js
@@ -215,4 +215,4 @@ export const OLD_CERT_LINKS = {
   }
 }
 
-export const NEW_TESTS_ENABLED = !!process.env.TEST_TAKING_ENABLED
+export const NEW_TESTS_ENABLED = true // !!process.env.TEST_TAKING_ENABLED

--- a/app/javascript/packs/MainApp/constants.js
+++ b/app/javascript/packs/MainApp/constants.js
@@ -215,4 +215,4 @@ export const OLD_CERT_LINKS = {
   }
 }
 
-export const NEW_TESTS_ENABLED = !!process.env.TEST_TAKING_ENABLED
+export const NEW_TESTS_ENABLED = process.env.TEST_TAKING_ENABLED === 'true'

--- a/app/javascript/packs/MainApp/routes.js
+++ b/app/javascript/packs/MainApp/routes.js
@@ -10,6 +10,7 @@ import Admin from './components/Admin'
 import RefereeDiagnostic from './components/RefereeDiagnostic'
 import Tests from './components/Tests'
 import Test from './components/Test'
+import StartTest from './components/StartTest'
 
 const App = () => (
   <Router>
@@ -17,11 +18,12 @@ const App = () => (
       <Route exact path='/' component={HomePage} />
       <Route exact path='/privacy' component={PrivacyPolicy} />
       <Route exact path='/referees' component={Referees} />
-      <Route path='/referees/:id' component={RefereeProfile} />
+      <Route exact path='/referees/:id' component={RefereeProfile} />
       <Route exact path='/admin' component={Admin} />
       <Route exact path='/admin/referee-diagnostic' component={RefereeDiagnostic} />
       <Route exact path='/admin/tests' component={Tests} />
-      <Route path='/admin/tests/:id' component={Test} />
+      <Route exact path='/admin/tests/:id' component={Test} />
+      <Route exact path='/referees/:refereeId/tests/:testId' component={StartTest} />
     </div>
   </Router>
 )

--- a/app/jobs/grade_job.rb
+++ b/app/jobs/grade_job.rb
@@ -1,0 +1,16 @@
+class GradeJob < ApplicationJob
+  queue_as :default
+  rescue_from ActiveJob::DeserializationError do
+    retry_job wait: 5.minutes
+  end
+
+  def perform(test, referee, test_timestamps, referee_answers)
+    Services::GradeFinishedTest.new(
+      test: test,
+      referee: referee,
+      started_at: test_timestamps[:started_at],
+      finished_at: test_timestamps[:finished_at],
+      referee_answers: referee_answers
+    ).perform
+  end
+end

--- a/app/jobs/grade_job.rb
+++ b/app/jobs/grade_job.rb
@@ -1,7 +1,7 @@
 class GradeJob < ApplicationJob
-  queue_as :default
-  rescue_from ActiveJob::DeserializationError do
-    retry_job wait: 5.minutes
+  queue_as :mailers
+  rescue_from ActiveJob::DeserializationError do |exception|
+    retry_job wait: 5.minutes unless exception.message.include? "Couldn't find"
   end
 
   def perform(test, referee, test_timestamps, referee_answers)

--- a/app/models/test.rb
+++ b/app/models/test.rb
@@ -21,6 +21,8 @@
 # This model stores the test information sent by classmarker.
 # It connects to our certification model to ensure the test result gives referees the right certification.
 class Test < ApplicationRecord
+  MAXIMUM_RETRIES = 6
+
   has_many :questions, dependent: :destroy
   has_many :referee_answers, dependent: :destroy
   has_many :test_attempts, dependent: :destroy

--- a/app/models/test_attempt.rb
+++ b/app/models/test_attempt.rb
@@ -39,4 +39,8 @@ class TestAttempt < ApplicationRecord
   def in_cool_down_period?
     Time.now.utc < next_attempt_at
   end
+
+  def hours_till_next_attempt
+    (((next_attempt_at - Time.now.utc) / 60) / 60).round
+  end
 end

--- a/app/serializers/answer_serializer.rb
+++ b/app/serializers/answer_serializer.rb
@@ -13,5 +13,5 @@
 class AnswerSerializer
   include FastJsonapi::ObjectSerializer
 
-  attributes :description, :correct, :question_id
+  attributes :description, :question_id
 end

--- a/app/serializers/answer_serializer.rb
+++ b/app/serializers/answer_serializer.rb
@@ -14,4 +14,5 @@ class AnswerSerializer
   include FastJsonapi::ObjectSerializer
 
   attributes :description, :question_id
+  attribute :correct, if: proc { |_referee, params| params && params[:include_correct] }
 end

--- a/app/services/grade_finished_test.rb
+++ b/app/services/grade_finished_test.rb
@@ -79,7 +79,7 @@ module Services
       recent_test_results = referee.test_results.send(test.level).order(created_at: :desc).last
       return false if recent_test_results.blank?
 
-      recent_test_results.created_at.to_date == Date.zone.today
+      recent_test_results.created_at.to_date == Date.today
     end
 
     def send_result_email(test_result)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,15 @@
+require 'sidekiq'
+require 'sidekiq-status'
+
+redis_url = ENV['REDIS_URL'] || ENV['REDISTOGO_URL']
+
+Sidekiq.configure_client do |config|
+  Sidekiq::Status.configure_client_middleware config
+end
+
+Sidekiq.configure_server do |config|
+  config.redis = { :url => redis_url }
+
+  Sidekiq::Status.configure_client_middleware config
+  Sidekiq::Status.configure_server_middleware config
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
   get 'admin/referee-diagnostic', to: 'home#index'
   get 'admin/tests', to: 'home#index'
   get 'admin/tests/:id', to: 'home#index'
+  get '/referees/:referee_id/tests/:test_id', to: 'home#index'
 
   post 'webhook', to: 'classmarker#webhook'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
+require 'sidekiq/web'
 
 Rails.application.routes.draw do
+  authenticate :referee, proc { |referee| referee.admin? } do
+    mount Sidekiq::Web => '/sidekiq'
+  end
+
   namespace :api do
     namespace :v1 do
       resources :referees, only: %i[index show update]

--- a/spec/controllers/api/v1/answers_controller_spec.rb
+++ b/spec/controllers/api/v1/answers_controller_spec.rb
@@ -135,6 +135,7 @@ RSpec.describe Api::V1::AnswersController, type: :controller do
       response_data = JSON.parse(response.body)['data']['attributes']
 
       expect(response_data['description']).to eq body_data[:description]
+      expect(response_data['correct']).to eq body_data[:correct]
       expect(response_data['question_id']).to eq body_data[:question_id]
     end
 

--- a/spec/controllers/api/v1/answers_controller_spec.rb
+++ b/spec/controllers/api/v1/answers_controller_spec.rb
@@ -135,7 +135,6 @@ RSpec.describe Api::V1::AnswersController, type: :controller do
       response_data = JSON.parse(response.body)['data']['attributes']
 
       expect(response_data['description']).to eq body_data[:description]
-      expect(response_data['correct']).to eq body_data[:correct]
       expect(response_data['question_id']).to eq body_data[:question_id]
     end
 

--- a/spec/controllers/api/v1/tests_controller_spec.rb
+++ b/spec/controllers/api/v1/tests_controller_spec.rb
@@ -73,6 +73,30 @@ RSpec.describe Api::V1::TestsController, type: :controller do
 
       expect(response_data.length).to eq tests.length
     end
+
+    context 'when active_only is true' do
+      let(:params) { { active_only: true } }
+      let(:active_test) { tests.first }
+
+      before { active_test.update!(active: true) }
+
+      subject { get :index, params: params }
+
+      it 'is a successful request' do
+        subject
+
+        expect(response).to have_http_status(:successful)
+      end
+
+      it 'only returns the active test' do
+        subject
+
+        response_data = JSON.parse(response.body)['data']
+
+        expect(response_data.length).to eq 1
+        expect(response_data[0]['id'].to_i).to eq active_test.id
+      end
+    end
   end
 
   describe 'POST #create' do

--- a/spec/controllers/api/v1/tests_controller_spec.rb
+++ b/spec/controllers/api/v1/tests_controller_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe Api::V1::TestsController, type: :controller do
 
     context 'when the test level is in the cool down period' do
       let!(:test_attempt) { create :test_attempt, test: test, referee: tester_ref }
-      let(:expected_error) { described_class::INVALID_TEST_ATTEMPT }
+      let(:expected_error) { "#{described_class::INVALID_TEST_ATTEMPT} 24 hours" }
 
       before { allow(test_attempt).to receive(:in_cool_down_period?).and_return(true) }
 

--- a/spec/controllers/api/v1/tests_controller_spec.rb
+++ b/spec/controllers/api/v1/tests_controller_spec.rb
@@ -278,6 +278,27 @@ RSpec.describe Api::V1::TestsController, type: :controller do
         expect(response_data).to eq expected_error
       end
     end
+
+    context 'when the referee has too many test attempts' do
+      let!(:test_attempts) { create_list :test_attempt, 6, test: test, referee: tester_ref, test_level: test.level }
+      let(:expected_error) { described_class::INVALID_TRY_COUNT }
+
+      before { allow_any_instance_of(TestAttempt).to receive(:in_cool_down_period?).and_return(false) }
+
+      it 'returns an error' do
+        subject
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'returns an error message' do
+        subject
+
+        response_data = JSON.parse(response.body)['error']
+
+        expect(response_data).to eq expected_error
+      end
+    end
   end
 
   describe 'POST #finish' do

--- a/spec/controllers/api/v1/tests_controller_spec.rb
+++ b/spec/controllers/api/v1/tests_controller_spec.rb
@@ -313,13 +313,12 @@ RSpec.describe Api::V1::TestsController, type: :controller do
       expect(response).to have_http_status(:successful)
     end
 
-    it 'returns the generated test result' do
+    it 'returns the generated grade job id' do
       subject
 
       response_data = JSON.parse(response.body)['data']
 
-      expect(response_data['type']).to eq 'test_result'
-      expect(response_data['attributes']['passed']).to eq true
+      expect(response_data['job_id']).to_not be_nil
     end
 
     context 'when the test grading fails' do
@@ -327,7 +326,7 @@ RSpec.describe Api::V1::TestsController, type: :controller do
       let(:error_message) { 'Error grading test' }
 
       before do
-        allow(Services::GradeFinishedTest).to receive(:new).and_raise(StandardError)
+        allow(GradeJob).to receive(:perform_later).and_raise(StandardError)
         allow(Bugsnag).to receive(:notify).and_call_original
       end
 

--- a/spec/jobs/grade_job_spec.rb
+++ b/spec/jobs/grade_job_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe GradeJob, type: :job do
+  let(:test_to_grade) { create :test }
+  let(:ref) { create :referee }
+  let(:test_timestamps) { { started_at: Time.now.utc.to_s, finished_at: Time.now.utc.to_s } }
+  let(:referee_answers) { [{ question_id: 1, answer_id: 2 }] }
+
+  subject { described_class.perform_later(test_to_grade, ref, test_timestamps, referee_answers) }
+
+  it 'should enqueue the job with the correct params' do
+    ActiveJob::Base.queue_adapter = :test
+
+    expect { subject }.to have_enqueued_job
+  end
+end

--- a/spec/jobs/grade_job_spec.rb
+++ b/spec/jobs/grade_job_spec.rb
@@ -11,6 +11,6 @@ RSpec.describe GradeJob, type: :job do
   it 'should enqueue the job with the correct params' do
     ActiveJob::Base.queue_adapter = :test
 
-    expect { subject }.to have_enqueued_job
+    expect { subject }.to have_enqueued_job.exactly(:once)
   end
 end


### PR DESCRIPTION
This PR adds the frontend for taking tests on the Referee Hub. Results are calculated in the background and are emailed to the referee. This feature is blocked by a "feature flag" meaning the old tests will still appear until we are ready to show them. Once merged this will mark the testing framework as code complete!

![gif of test taking](https://cl.ly/9894c4254b20/Screen%252520Recording%2525202019-08-12%252520at%25252005.14%252520PM.gif)