### PR TITLE
Fixes head ref test not being displayed

### DIFF
--- a/app/javascript/packs/MainApp/components/CertificationLinks.jsx
+++ b/app/javascript/packs/MainApp/components/CertificationLinks.jsx
@@ -78,13 +78,14 @@ class CertificationLinks extends Component {
 
   get certificationConfig() {
     const { testLinks } = this.state
+    const { hasPaid } = this.props
 
     if (NEW_TESTS_ENABLED) {
       const groupedLinks = groupBy(testLinks, 'language')
       return groupedLinks
     }
 
-    return CERT_LINKS(this.canTakeSnitchTest(), this.canTakeAssistantTest(), this.canTakeHeadTest())
+    return CERT_LINKS(this.canTakeSnitchTest(), this.canTakeAssistantTest(), this.canTakeHeadTest(hasPaid))
   }
 
   isTestEnabled = (testLevel) => {


### PR DESCRIPTION
A necessary argument wasn't being passed which resulted in the head ref tests not being displayed.