### PR TITLE
Fix float domain error

### DIFF
--- a/app/services/grade_finished_test.rb
+++ b/app/services/grade_finished_test.rb
@@ -84,8 +84,8 @@ module Services
 
     def calculate_duration
       general = TimeDifference.between(started_at, finished_at).in_general
-      seconds = general[:seconds].zero? ? '00' : general[:seconds]
-      minutes = general[:minutes].zero? ? '00' : general[:minutes]
+      seconds = general[:seconds] < 10 ? "0#{general[:seconds]}" : general[:seconds]
+      minutes = general[:minutes] < 10 ? "0#{general[:minutes]}" : general[:minutes]
 
       "00:#{minutes}:#{seconds}"
     end

--- a/app/services/grade_finished_test.rb
+++ b/app/services/grade_finished_test.rb
@@ -59,7 +59,7 @@ module Services
 
     def create_test_result(points_scored, points_available)
       return nil if already_has_test_result?
-      percentage = ((points_scored.to_f / points_available) * 100).round
+      percentage = calculate_percentage(points_scored, points_available)
       is_over_limit = TimeDifference.between(started_at, finished_at).in_minutes > test.time_limit
       test_results_hash = {
         duration: calculate_duration.to_s,
@@ -88,6 +88,12 @@ module Services
       minutes = general[:minutes].zero? ? '00' : general[:minutes]
 
       "00:#{minutes}:#{seconds}"
+    end
+
+    def calculate_percentage(points_scored, points_available)
+      return 0 if points_scored.zero? || points_available.zero?
+
+      ((points_scored.to_f / points_available) * 100).round
     end
 
     def send_result_email(test_result)

--- a/spec/services/grade_finished_test_spec.rb
+++ b/spec/services/grade_finished_test_spec.rb
@@ -114,4 +114,30 @@ describe Services::GradeFinishedTest do
       end
     end
   end
+
+  context 'when points scored or available are 0' do
+    let(:referee_answers) { [] }
+    let(:expected_test_result) do
+      {
+        test_id: test.id,
+        referee_id: referee.id,
+        duration: '00:15:00',
+        minimum_pass_percentage: test.minimum_pass_percentage,
+        passed: false,
+        percentage: 0,
+        points_available: 0,
+        points_scored: 0,
+        test_level: test.level
+      }
+    end
+
+    it 'creates a test attempt' do
+      expect { subject }.to change { referee.test_attempts.count }.by(1)
+      expect(referee.test_attempts.last.test).to eq test
+    end
+
+    it 'returns a test result' do
+      expect(subject).to have_attributes(expected_test_result)
+    end
+  end
 end


### PR DESCRIPTION
Recently we've gotten this error on bugsnag:

```
FloatDomainError
GradeJob@mailers
NaN
Nov 5th, 2019, 13:24:28 UTC

app/services/grade_finished_test.rb:62:in `round': NaN (FloatDomainError)
    from app/services/grade_finished_test.rb:62:in `create_test_result'
    from app/services/grade_finished_test.rb:57:in `grade_answers'
    from app/services/grade_finished_test.rb:19:in `perform'
    from app/jobs/grade_job.rb:14:in `perform'
```

This is due to points scored or points available being zero. It turns out this issue was twofold as a ref could go through the test without actually answering the questions. We've fixed this issue so the service doesn't error when zero values are present and also preventing referees from not selecting answers during the test. I also fixed a small test duration rendering bug that was bothering me.