### PR TITLE
Creates user and role models

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,0 +1,31 @@
+# == Schema Information
+#
+# Table name: roles
+#
+#  id          :bigint(8)        not null, primary key
+#  access_type :integer          default("referee"), not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  user_id     :bigint(8)
+#
+# Indexes
+#
+#  index_roles_on_user_id                  (user_id)
+#  index_roles_on_user_id_and_access_type  (user_id,access_type) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+
+class Role < ApplicationRecord
+  enum access_type: {
+    referee: 0,
+    ngb_admin: 1,
+    iqa_admin: 2
+  }
+
+  validates :access_type, uniqueness: { scope: :user_id }
+
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,53 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                           :bigint(8)        not null, primary key
+#  bio                          :text
+#  confirmation_sent_at         :datetime
+#  confirmation_token           :string
+#  confirmed_at                 :datetime
+#  current_sign_in_at           :datetime
+#  current_sign_in_ip           :inet
+#  email                        :string           default(""), not null
+#  encrypted_password           :string           default(""), not null
+#  failed_attempts              :integer          default(0), not null
+#  first_name                   :string
+#  getting_started_dismissed_at :datetime
+#  last_name                    :string
+#  last_sign_in_at              :datetime
+#  last_sign_in_ip              :inet
+#  locked_at                    :datetime
+#  pronouns                     :string
+#  remember_created_at          :datetime
+#  reset_password_sent_at       :datetime
+#  reset_password_token         :string
+#  show_pronouns                :boolean          default(FALSE)
+#  sign_in_count                :integer          default(0), not null
+#  submitted_payment_at         :datetime
+#  unlock_token                 :string
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_unlock_token          (unlock_token) UNIQUE
+#
+
+class User < ApplicationRecord
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :trackable, :validatable, :confirmable, :lockable
+
+  has_many :roles, dependent: :destroy
+
+  protected
+
+  def confirmation_required?
+    return true unless Rails.env.test?
+
+    false
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -149,7 +149,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
-  # config.remember_for = 2.weeks
+  config.remember_for = 4.weeks
 
   # Invalidates all the remember me tokens when the user signs out.
   config.expire_all_remember_me_on_sign_out = true
@@ -179,27 +179,27 @@ Devise.setup do |config|
   # Defines which strategy will be used to lock an account.
   # :failed_attempts = Locks an account after a number of failed attempts to sign in.
   # :none            = No lock strategy. You should handle locking by yourself.
-  # config.lock_strategy = :failed_attempts
+  config.lock_strategy = :failed_attempts
 
   # Defines which key will be used when locking and unlocking an account
-  # config.unlock_keys = [:email]
+  config.unlock_keys = [:email]
 
   # Defines which strategy will be used to unlock an account.
   # :email = Sends an unlock link to the user email
   # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
   # :both  = Enables both strategies
   # :none  = No unlock strategy. You should handle unlocking by yourself.
-  # config.unlock_strategy = :both
+  config.unlock_strategy = :email
 
   # Number of authentication tries before locking an account if lock_strategy
   # is failed attempts.
-  # config.maximum_attempts = 20
+  config.maximum_attempts = 8
 
   # Time interval to unlock the account if :time is enabled as unlock_strategy.
   # config.unlock_in = 1.hour
 
   # Warn on the last attempt before the account is locked.
-  # config.last_attempt_warning = true
+  config.last_attempt_warning = true
 
   # ==> Configuration for :recoverable
   #

--- a/db/migrate/20191123130224_devise_create_users.rb
+++ b/db/migrate/20191123130224_devise_create_users.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class DeviseCreateUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :users do |t|
+      ## Database authenticatable
+      t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      t.integer  :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.inet     :current_sign_in_ip
+      t.inet     :last_sign_in_ip
+
+      ## Confirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+
+      ## Lockable
+      t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      t.string   :unlock_token # Only if unlock strategy is :email or :both
+      t.datetime :locked_at
+
+      t.string :first_name
+      t.string :last_name
+      t.text :bio
+      t.string :pronouns
+      t.boolean :show_pronouns, default: false
+      t.datetime :submitted_payment_at
+      t.datetime :getting_started_dismissed_at
+
+      t.timestamps null: false
+    end
+
+    add_index :users, :email,                unique: true
+    add_index :users, :reset_password_token, unique: true
+    add_index :users, :confirmation_token,   unique: true
+    add_index :users, :unlock_token,         unique: true
+  end
+end

--- a/db/migrate/20191123140602_create_roles.rb
+++ b/db/migrate/20191123140602_create_roles.rb
@@ -1,0 +1,12 @@
+class CreateRoles < ActiveRecord::Migration[5.2]
+  def change
+    create_table :roles do |t|
+      t.references :user, foreign_key: true
+      t.integer :access_type, default: 0, null: false
+
+      t.timestamps
+    end
+
+    add_index :roles, [:user_id, :access_type], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_16_232934) do
+ActiveRecord::Schema.define(version: 2019_11_23_140602) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -140,6 +140,15 @@ ActiveRecord::Schema.define(version: 2019_11_16_232934) do
     t.index ["reset_password_token"], name: "index_referees_on_reset_password_token", unique: true
   end
 
+  create_table "roles", force: :cascade do |t|
+    t.bigint "user_id"
+    t.integer "access_type", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "access_type"], name: "index_roles_on_user_id_and_access_type", unique: true
+    t.index ["user_id"], name: "index_roles_on_user_id"
+  end
+
   create_table "social_accounts", force: :cascade do |t|
     t.string "ownable_type"
     t.bigint "ownable_id"
@@ -216,9 +225,42 @@ ActiveRecord::Schema.define(version: 2019_11_16_232934) do
     t.integer "testable_question_count", default: 0, null: false
   end
 
+  create_table "users", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.inet "current_sign_in_ip"
+    t.inet "last_sign_in_ip"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.integer "failed_attempts", default: 0, null: false
+    t.string "unlock_token"
+    t.datetime "locked_at"
+    t.string "first_name"
+    t.string "last_name"
+    t.text "bio"
+    t.string "pronouns"
+    t.boolean "show_pronouns", default: false
+    t.datetime "submitted_payment_at"
+    t.datetime "getting_started_dismissed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
+  end
+
   add_foreign_key "national_governing_body_stats", "national_governing_bodies"
   add_foreign_key "referee_teams", "referees"
   add_foreign_key "referee_teams", "teams"
+  add_foreign_key "roles", "users"
   add_foreign_key "team_status_changesets", "teams"
   add_foreign_key "teams", "national_governing_bodies"
 end

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: roles
+#
+#  id          :bigint(8)        not null, primary key
+#  access_type :integer          default("referee"), not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  user_id     :bigint(8)
+#
+# Indexes
+#
+#  index_roles_on_user_id                  (user_id)
+#  index_roles_on_user_id_and_access_type  (user_id,access_type) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+
+FactoryBot.define do
+  factory :role do
+    user { create :user }
+    access_type 0
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,47 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                           :bigint(8)        not null, primary key
+#  bio                          :text
+#  confirmation_sent_at         :datetime
+#  confirmation_token           :string
+#  confirmed_at                 :datetime
+#  current_sign_in_at           :datetime
+#  current_sign_in_ip           :inet
+#  email                        :string           default(""), not null
+#  encrypted_password           :string           default(""), not null
+#  failed_attempts              :integer          default(0), not null
+#  first_name                   :string
+#  getting_started_dismissed_at :datetime
+#  last_name                    :string
+#  last_sign_in_at              :datetime
+#  last_sign_in_ip              :inet
+#  locked_at                    :datetime
+#  pronouns                     :string
+#  remember_created_at          :datetime
+#  reset_password_sent_at       :datetime
+#  reset_password_token         :string
+#  show_pronouns                :boolean          default(FALSE)
+#  sign_in_count                :integer          default(0), not null
+#  submitted_payment_at         :datetime
+#  unlock_token                 :string
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_unlock_token          (unlock_token) UNIQUE
+#
+
+FactoryBot.define do
+  factory :user do
+    first_name { FFaker::Name.first_name }
+    last_name { FFaker::Name.last_name }
+    email { "#{first_name}.#{last_name}@example.com" }
+    password { 'password' }
+  end
+end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -1,0 +1,37 @@
+# == Schema Information
+#
+# Table name: roles
+#
+#  id          :bigint(8)        not null, primary key
+#  access_type :integer          default("referee"), not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  user_id     :bigint(8)
+#
+# Indexes
+#
+#  index_roles_on_user_id                  (user_id)
+#  index_roles_on_user_id_and_access_type  (user_id,access_type) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+
+require 'rails_helper'
+
+RSpec.describe Role, type: :model do
+  let(:role) { build :role }
+
+  subject { role.valid? }
+
+  it { expect(subject).to be_truthy }
+
+  context 'when a user already has a role' do
+    let(:user) { create :user }
+    let!(:existing_role) { create :role, user: user, access_type: 'ngb_admin' }
+    let(:role) { build :role, user: user, access_type: 'ngb_admin' }
+
+    it { expect(subject).to be_falsey }
+  end
+end


### PR DESCRIPTION
The user model will be the main authentication table going forward. A user can have multiple roles but can not have more than one of each access type. These changes do not include changing routes or migrating the referee table to the user table.