### PR TITLE
Ensures referee role

### DIFF
--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -2,13 +2,10 @@ module DeviseHelper
   def devise_error_messages!
     return '' unless devise_error_messages?
 
-    messages = resource.errors.full_messages.map { |msg| content_tag(:li, msg) }.join
-    sentence = 'Uh Oh! Looks like there were some issues creating your account'
-
     html = <<-HTML
     <div id='error_explanation' class='ui error message'>
-      <h2>#{sentence}</h2>
-      <ul class='list'>#{messages}</ul>
+      <h2>#{fetch_sentence}</h2>
+      <ul class='list'>#{fetch_messages}</ul>
     </div>
     HTML
 
@@ -16,7 +13,11 @@ module DeviseHelper
   end
 
   def devise_error_messages?
-    !resource.errors.empty?
+    !resource.errors.empty? || flash_errors?
+  end
+
+  def flash_errors?
+    flash.present?
   end
 
   def email_error?
@@ -29,5 +30,21 @@ module DeviseHelper
 
   def password_confirmation_error?
     !resource.errors[:password_confirmation].empty?
+  end
+
+  private
+
+  def fetch_messages
+    if flash_errors?
+      content_tag(:li, flash[:alert])
+    else
+      resource.errors.full_messages.map { |msg| content_tag(:li, msg) }.join
+    end
+  end
+
+  def fetch_sentence
+    return '' if flash_errors?
+
+    'Uh Oh! Looks like there were some issues with your account'
   end
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -28,4 +28,8 @@ class Role < ApplicationRecord
   validates :access_type, uniqueness: { scope: :user_id }
 
   belongs_to :user
+
+  scope :referee, -> { where(access_type: 'referee') }
+  scope :ngb_admin, -> { where(access_type: 'ngb_admin') }
+  scope :iqa_admin, -> { where(access_type: 'iqa_admin') }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,6 +63,7 @@ class User < ApplicationRecord
   scope :referee, -> { where(roles: { access_type: 'referee' }) }
 
   self.per_page = 25
+  attr_accessor :disable_ensure_role
 
   after_save :ensure_role, on: :create
 
@@ -81,7 +82,8 @@ class User < ApplicationRecord
   private
 
   def ensure_role
-    return if roles.present?
+    return if disable_ensure_role.present?
+    return if roles.present? || roles.referee.present?
 
     Role.create!(user_id: id, access_type: 'referee')
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,34 +6,6 @@ Rails.application.routes.draw do
     mount Sidekiq::Web => '/sidekiq'
   end
 
-  namespace :api do
-    namespace :v1 do
-      resources :users, only: %i[index show update]
-      resources :national_governing_bodies, only: %i[index show]
-      resources :referee_certifications, only: %i[index create update]
-      resources :tests, only: %i[index create show update destroy] do
-        resources :questions, shallow: true do
-          resources :answers, shallow: true
-        end
-
-        member do
-          get :start
-          post :finish
-        end
-      end
-
-      scope '/admin' do
-        post '/search' => 'diagnostic#search'
-        patch '/update-payment' => 'diagnostic#update_payment'
-      end
-
-      post 'tests/import', to: 'tests#import'
-      get 'referees' => 'referees#index'
-      get 'referees/:id' => 'referees#show'
-      put 'referees/:id' => 'referees#update'
-    end
-  end
-
   get 'home/index'
   get 'referees', to: 'home#index'
   get 'referees/:id', to: 'home#index'
@@ -65,6 +37,35 @@ Rails.application.routes.draw do
   end
 
   devise_for :users, skip: :all
+
+  namespace :api do
+    namespace :v1 do
+      resources :users, only: %i[index show update]
+      resources :national_governing_bodies, only: %i[index show]
+      resources :referee_certifications, only: %i[index create update]
+      resources :tests, only: %i[index create show update destroy] do
+        resources :questions, shallow: true do
+          resources :answers, shallow: true
+        end
+
+        member do
+          get :start
+          post :finish
+        end
+      end
+
+      scope '/admin' do
+        post '/search' => 'diagnostic#search'
+        patch '/update-payment' => 'diagnostic#update_payment'
+      end
+
+      post 'tests/import', to: 'tests#import'
+      get 'referees' => 'referees#index'
+      get 'referees/:id' => 'referees#show'
+      put 'referees/:id' => 'referees#update'
+    end
+  end
+
 
   root to: 'home#index'
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,11 +1,3 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
-
 NGB_CONFIG = [
   {
     name: 'Argentina',
@@ -194,4 +186,9 @@ CERT_CONFIG = [
 
 CERT_CONFIG.each do |config|
   Certification.find_or_create_by(display_name: config[:display_name], level: config[:level])
+end
+
+USER_ROLES = %w[referee iqa_admin ngb_admin]
+USER_ROLES.each do |access_type|
+  FactoryBot.create(:user, password: 'password', roles_attributes: [{ access_type: access_type }])
 end

--- a/spec/controllers/api/v1/_shared_examples.rb
+++ b/spec/controllers/api/v1/_shared_examples.rb
@@ -1,5 +1,5 @@
 shared_examples 'it fails when a referee is not an admin' do
-  let(:other_ref) { create :user, :referee }
+  let(:other_ref) { create :user }
   let(:expected_error) { ApplicationController::USER_UNAUTHORIZED }
 
   before { sign_in other_ref }

--- a/spec/controllers/api/v1/answers_controller_spec.rb
+++ b/spec/controllers/api/v1/answers_controller_spec.rb
@@ -3,7 +3,7 @@ require_relative '_shared_examples'
 
 RSpec.describe Api::V1::AnswersController, type: :controller do
   let(:admin) { create :user, :iqa_admin }
-  let(:non_admin) { create :user, :referee }
+  let(:non_admin) { create :user }
   let!(:test) { create :test }
   let!(:question) { create :question, test: test }
 

--- a/spec/controllers/api/v1/diagnostic_controller_spec.rb
+++ b/spec/controllers/api/v1/diagnostic_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::DiagnosticController, type: :controller do
   let(:admin) { create :user, :iqa_admin }
-  let!(:search_ref) { create :user, :referee }
+  let!(:search_ref) { create :user }
 
   describe 'POST #search' do
     before { sign_in admin }
@@ -68,7 +68,7 @@ RSpec.describe Api::V1::DiagnosticController, type: :controller do
   end
 
   context 'when signed in referee is not an admin' do
-    let(:other_ref) { create :user, :referee }
+    let(:other_ref) { create :user }
     let(:body_data) { { referee_search: search_ref.email } }
     let(:expected_error) { ApplicationController::USER_UNAUTHORIZED }
 

--- a/spec/controllers/api/v1/questions_controller_spec.rb
+++ b/spec/controllers/api/v1/questions_controller_spec.rb
@@ -3,7 +3,7 @@ require_relative '_shared_examples'
 
 RSpec.describe Api::V1::QuestionsController, type: :controller do
   let(:admin) { create :user, :iqa_admin }
-  let(:non_admin) { create :user, :referee }
+  let(:non_admin) { create :user }
   let!(:test) { create :test }
 
   describe 'GET #index' do

--- a/spec/controllers/api/v1/referee_certifications_controller_spec.rb
+++ b/spec/controllers/api/v1/referee_certifications_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::RefereeCertificationsController, type: :controller do
   describe 'GET #index' do
-    let!(:referee) { create :user, :referee }
+    let!(:referee) { create :user }
     let!(:assistant) { create :referee_certification, referee: referee }
     let!(:snitch) { create :referee_certification, :snitch, referee: referee }
     let!(:head) { create :referee_certification, :head, referee: referee }
@@ -37,7 +37,7 @@ RSpec.describe Api::V1::RefereeCertificationsController, type: :controller do
   end
 
   describe 'POST #update' do
-    let!(:referee) { create :user, :referee }
+    let!(:referee) { create :user }
     let!(:assistant) { create :referee_certification, referee: referee }
 
     before { sign_in referee }

--- a/spec/controllers/api/v1/referees_controller_spec.rb
+++ b/spec/controllers/api/v1/referees_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::RefereesController, type: :controller do
   describe 'GET #index' do
-    let!(:referees) { create_list :user, 3, :referee }
+    let!(:referees) { create_list :user, 3 }
 
     subject { get :index }
 
@@ -115,7 +115,7 @@ RSpec.describe Api::V1::RefereesController, type: :controller do
   end
 
   describe 'GET #show' do
-    let!(:referee) { create :user, :referee }
+    let!(:referee) { create :user }
 
     subject { get :show, params: { id: referee.id } }
 
@@ -151,7 +151,7 @@ RSpec.describe Api::V1::RefereesController, type: :controller do
     end
 
     context 'when the referee signed in is different than the one being shown' do
-      let!(:other_ref) { create :user, :referee }
+      let!(:other_ref) { create :user }
 
       before { sign_in other_ref }
 
@@ -166,7 +166,7 @@ RSpec.describe Api::V1::RefereesController, type: :controller do
   end
 
   describe 'POST #update' do
-    let!(:referee) { create :user, :referee }
+    let!(:referee) { create :user }
     let!(:national_governing_bodies) { create_list :national_governing_body, 3 }
     let(:ngb_ids) { national_governing_bodies.pluck(:id) }
 

--- a/spec/controllers/api/v1/tests_controller_spec.rb
+++ b/spec/controllers/api/v1/tests_controller_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe Api::V1::TestsController, type: :controller do
   end
 
   describe 'GET #start' do
-    let(:tester_ref) { create :user, :referee }
+    let(:tester_ref) { create :user }
     let(:question_count) { 2 }
     let(:test) { create :test, testable_question_count: question_count }
     let!(:questions) { create_list(:question, 5, test: test) }
@@ -254,7 +254,7 @@ RSpec.describe Api::V1::TestsController, type: :controller do
   end
 
   describe 'POST #finish' do
-    let(:tester_ref) { create :user, :referee }
+    let(:tester_ref) { create :user }
     let(:test) { create :test }
     let(:questions) { create_list(:question, 5, test: test) }
     let(:started_at) { Time.now.utc }

--- a/spec/factories/referee_answers.rb
+++ b/spec/factories/referee_answers.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
   factory :referee_answer do
     answer { create :answer }
     question { create :question }
-    referee { create :user, :referee }
+    referee { create :user }
     test_attempt { create :test_attempt }
     test { create :test }
   end

--- a/spec/factories/referee_certifications.rb
+++ b/spec/factories/referee_certifications.rb
@@ -19,7 +19,7 @@
 
 FactoryBot.define do
   factory :referee_certification do
-    referee { create :user, :referee }
+    referee { create :user }
     certification { create :certification }
     received_at { DateTime.now.utc }
     revoked_at nil

--- a/spec/factories/referee_locations.rb
+++ b/spec/factories/referee_locations.rb
@@ -15,7 +15,7 @@
 
 FactoryBot.define do
   factory :referee_location do
-    referee { create :user, :referee }
+    referee { create :user }
     national_governing_body { create :national_governing_body }
   end
 end

--- a/spec/factories/referee_teams.rb
+++ b/spec/factories/referee_teams.rb
@@ -24,7 +24,7 @@
 FactoryBot.define do
   factory :referee_team do
     team { create :team }
-    referee { create :user, :referee }
+    referee { create :user }
     association_type 0
   end
 end

--- a/spec/factories/test_attempts.rb
+++ b/spec/factories/test_attempts.rb
@@ -13,7 +13,7 @@
 
 FactoryBot.define do
   factory :test_attempt do
-    referee { create :user, :referee }
+    referee { create :user }
     test_level 0
   end
 end

--- a/spec/factories/test_results.rb
+++ b/spec/factories/test_results.rb
@@ -26,7 +26,7 @@
 
 FactoryBot.define do
   factory :test_result do
-    referee { create :user, :referee }
+    referee { create :user }
     time_started { Time.zone.now }
     time_finished { Time.zone.now + 1.hour }
     percentage 70

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -45,12 +45,6 @@ FactoryBot.define do
     email { "#{first_name}.#{last_name}@example.com" }
     password { 'password' }
 
-    trait :referee do
-      after(:create) do |user, _|
-        create(:role, access_type: 'referee', user: user)
-      end
-    end
-
     trait :iqa_admin do
       after(:create) do |user, _|
         create(:role, access_type: 'iqa_admin', user: user)

--- a/spec/jobs/grade_job_spec.rb
+++ b/spec/jobs/grade_job_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe GradeJob, type: :job do
   let(:test_to_grade) { create :test }
-  let(:ref) { create :user, :referee }
+  let(:ref) { create :user }
   let(:test_timestamps) { { started_at: Time.now.utc.to_s, finished_at: Time.now.utc.to_s } }
   let(:referee_answers) { [{ question_id: 1, answer_id: 2 }] }
 

--- a/spec/models/national_governing_body_spec.rb
+++ b/spec/models/national_governing_body_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe NationalGoverningBody, type: :model do
   end
 
   context 'with associated referees' do
-    let(:ref_1) { create :user, :referee }
-    let(:ref_2) { create :user, :referee }
-    let(:ref_3) { create :user, :referee }
+    let(:ref_1) { create :user }
+    let(:ref_2) { create :user }
+    let(:ref_3) { create :user }
     let(:ngb) { build :national_governing_body }
 
     before { ngb.referees << [ref_1, ref_2] }

--- a/spec/models/referee_certification_spec.rb
+++ b/spec/models/referee_certification_spec.rb
@@ -20,7 +20,7 @@
 require 'rails_helper'
 
 RSpec.describe RefereeCertification, type: :model do
-  let(:referee) { create :user, :referee }
+  let(:referee) { create :user }
   let(:certification) { create :certification }
   let(:ref_cert) { build :referee_certification, referee: referee, certification: certification }
 

--- a/spec/models/referee_location_spec.rb
+++ b/spec/models/referee_location_spec.rb
@@ -16,7 +16,7 @@
 require 'rails_helper'
 
 RSpec.describe RefereeLocation, type: :model do
-  let(:referee) { create :user, :referee }
+  let(:referee) { create :user }
   let(:ngb) { create :national_governing_body }
   let(:ref_location) { build :referee_location, referee: referee, national_governing_body: ngb }
 

--- a/spec/models/referee_team_spec.rb
+++ b/spec/models/referee_team_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe RefereeTeam, type: :model do
 
   context 'when a referee already has a team' do
     let(:ngb) { create :national_governing_body }
-    let(:referee) { create :user, :referee }
+    let(:referee) { create :user }
     let(:team_1) { create :team, national_governing_body: ngb }
     let(:team_2) { create :team, national_governing_body: ngb }
     let!(:existing_referee_team) { create :referee_team, team: team_1, referee: referee, association_type: 'player' }

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -21,7 +21,8 @@
 require 'rails_helper'
 
 RSpec.describe Role, type: :model do
-  let(:role) { build :role }
+  let(:user) { create :user, disable_ensure_role: true }
+  let(:role) { build :role, user: user }
 
   subject { role.valid? }
 

--- a/spec/models/test_result_spec.rb
+++ b/spec/models/test_result_spec.rb
@@ -27,7 +27,7 @@
 require 'rails_helper'
 
 RSpec.describe TestResult, type: :model do
-  let(:referee) { create :user, :referee }
+  let(:referee) { create :user }
   let(:test) { create :test }
   let(:test_result) { build :test_result, referee: referee, test_level: :assistant, test: test }
   let!(:existing_certification) { create :certification }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -50,6 +50,12 @@ RSpec.describe User, type: :model do
     expect(user.show_pronouns).to eq false
   end
 
+  it 'should create a referee role if one is not passed initially' do
+    subject
+    expect(user.reload.roles.length).to eq 1
+    expect(user.reload.roles.first.access_type).to eq 'referee'
+  end
+
   context 'with an associated NGB' do
     let(:ngb_1) { create :national_governing_body, name: 'United States' }
     let(:ngb_2) { create :national_governing_body, name: 'France' }
@@ -60,6 +66,16 @@ RSpec.describe User, type: :model do
     it 'returns the correct ngbs' do
       subject
       expect(user.national_governing_bodies.pluck(:id)).to include(ngb_1.id, ngb_2.id)
+    end
+  end
+
+  context 'with an associated role' do
+    let(:user) { build :user, roles_attributes: [{ access_type: 'iqa_admin' }] }
+
+    it 'only creates the passed role' do
+      subject
+      expect(user.roles.length).to eq 1
+      expect(user.roles.first.access_type).to eq 'iqa_admin'
     end
   end
 end

--- a/spec/services/add_roles_to_users_spec.rb
+++ b/spec/services/add_roles_to_users_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe Services::AddRolesToUsers do
-  let(:users) { create_list :user, 5 }
-  let(:admin_users) { create_list :user, 3, admin: true }
+  let(:users) { create_list :user, 5, disable_ensure_role: true }
+  let(:admin_users) { create_list :user, 3, admin: true, disable_ensure_role: true }
   let(:combined_users) { users.concat(admin_users) }
 
   subject { described_class.new(users: combined_users).perform }

--- a/spec/services/filter_referees_spec.rb
+++ b/spec/services/filter_referees_spec.rb
@@ -4,7 +4,7 @@ require 'json'
 RSpec.describe Services::FilterReferees do
   let(:ngb) { create :national_governing_body }
   let(:cert) { create :certification, :snitch }
-  let(:referees) { create_list :user, 3, :referee }
+  let(:referees) { create_list :user, 3 }
   let(:search_query) { 'test' }
   let(:certifications) { ['snitch'] }
   let(:ngbs) { [ngb.id] }
@@ -74,7 +74,7 @@ RSpec.describe Services::FilterReferees do
   end
 
   context 'when searching by name' do
-    let!(:referee) { create :user, :referee }
+    let!(:referee) { create :user }
     let(:search_query) { 'nap' }
     let(:params) { { q: search_query } }
 
@@ -148,7 +148,7 @@ RSpec.describe Services::FilterReferees do
     let(:certifications) { nil }
     let(:ngbs) { nil }
 
-    before { create_list(:user, 3, :iqa_admin) }
+    before { create_list(:user, 3, roles_attributes: [{ access_type: 'iqa_admin' }]) }
 
     it 'should return only referee user types' do
       expect(subject.length).to eq referees.length

--- a/spec/services/grade_finished_test_spec.rb
+++ b/spec/services/grade_finished_test_spec.rb
@@ -7,7 +7,7 @@ describe Services::GradeFinishedTest do
   let!(:certification) { create :certification, :snitch }
   let(:test) { create :test }
   let(:questions) { create_list(:question, 5, test: test) }
-  let(:referee) { create :user, :referee }
+  let(:referee) { create :user }
   let(:started_at) { Time.now.utc }
   let(:finished_at) { Time.now.utc + 15.minutes }
   let(:referee_answers) do


### PR DESCRIPTION
Until we build out the functionality for IQA/NGB admins we need to ensure users are created with a referee role (unless otherwise stated). There was also some cleanup for error messages.