### PR TITLE
Adds necessary gems for s3 storage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,8 @@ gem 'sidekiq-status'
 gem 'activerecord-import'
 gem 'time_difference'
 gem 'gdpr_rails'
+gem 'aws-sdk-s3', '~> 1'
+gem 'paperclip', '~> 6.0.0'
 
 # feature flippers
 gem 'flipper'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,22 @@ GEM
       io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
+    aws-eventstream (1.0.3)
+    aws-partitions (1.261.0)
+    aws-sdk-core (3.86.0)
+      aws-eventstream (~> 1.0, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.27.0)
+      aws-sdk-core (~> 3, >= 3.71.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.60.1)
+      aws-sdk-core (~> 3, >= 3.83.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.1.0)
+      aws-eventstream (~> 1.0, >= 1.0.2)
     barnes (0.0.7)
       multi_json (~> 1)
       statsd-ruby (~> 1.1)
@@ -81,6 +97,7 @@ GEM
       nokogiri (~> 1.8)
     chronic_duration (0.10.6)
       numerizer (~> 0.1.1)
+    climate_control (0.2.0)
     codecov (0.1.10)
       json
       simplecov
@@ -136,6 +153,7 @@ GEM
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
     jaro_winkler (1.5.1)
+    jmespath (1.4.0)
     json (2.1.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -149,6 +167,9 @@ GEM
     marcel (0.3.2)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.1009)
     mimemagic (0.3.2)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
@@ -160,6 +181,12 @@ GEM
       mini_portile2 (~> 2.4.0)
     numerizer (0.1.1)
     orm_adapter (0.5.0)
+    paperclip (6.0.0)
+      activemodel (>= 4.2.0)
+      activesupport (>= 4.2.0)
+      mime-types
+      mimemagic (~> 0.3.0)
+      terrapin (~> 0.6.0)
     parallel (1.12.1)
     parser (2.5.1.2)
       ast (~> 2.4.0)
@@ -281,6 +308,8 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     statsd-ruby (1.4.0)
+    terrapin (0.6.0)
+      climate_control (>= 0.0.3, < 1.0)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -317,6 +346,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord-import
   annotate
+  aws-sdk-s3 (~> 1)
   barnes
   bootsnap (>= 1.1.0)
   bugsnag (~> 6.11)
@@ -336,6 +366,7 @@ DEPENDENCIES
   gdpr_rails
   listen (>= 3.0.5, < 3.2)
   loofah (>= 2.2.3)
+  paperclip (~> 6.0.0)
   pg (>= 0.18, < 2.0)
   pre-commit
   puma (~> 3.12)


### PR DESCRIPTION
Stemming from this issue (https://github.com/prey/gdpr_rails/issues/43) we needed to specifally load two gems in our gemfile.