### PR TITLE
Removes api call for a serialized boolean

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -10,15 +10,7 @@ class Users::SessionsController < Devise::SessionsController
 
   # POST /resource/sign_in
   def create
-    super do |resource|
-      return if resource.has_consented_privacy_terms?
-
-      if sign_in_params.fetch(:policy_rule_privacy_terms)
-        resource.confirm_all_policies!
-      else
-        resource.reject_all_policies!
-      end
-    end
+    super
   end
 
   # DELETE /resource/sign_out

--- a/app/javascript/packs/MainApp/components/RefereeProfile.jsx
+++ b/app/javascript/packs/MainApp/components/RefereeProfile.jsx
@@ -34,7 +34,8 @@ class RefereeProfile extends Component {
       testAttempts: [],
       testResults: [],
       isEditable: false,
-      submittedPaymentAt: null
+      submittedPaymentAt: null,
+      hasPendingPolicies: false,
     },
     paymentError: false,
     paymentSuccess: false,
@@ -53,13 +54,6 @@ class RefereeProfile extends Component {
       .get(this.currentRefereeApiRoute)
       .then(this.setComponentStateFromBackendData)
       .catch(this.setErrorStateFromBackendData)
-
-    axios.get('/policies/user_terms/pending.json')
-      .then(({ data }) => {
-        if (!data.length) {
-          this.setState({ policyAccepted: true })
-        }
-      })
   }
 
   get currentRefereeApiRoute() {
@@ -128,8 +122,9 @@ class RefereeProfile extends Component {
         testResults,
         isEditable: attributes.is_editable,
         submittedPaymentAt: attributes.submitted_payment_at,
-        gettingStartedDismissedAt: attributes.getting_started_dismissed_at
-      }
+        gettingStartedDismissedAt: attributes.getting_started_dismissed_at,
+      },
+      policyAccepted: !attributes.has_pending_policies
     })
   }
 
@@ -318,7 +313,8 @@ class RefereeProfile extends Component {
   }
 
   renderAcceptPolicy = () => {
-    const { policyAccepted } = this.state
+    const { policyAccepted, referee: { isEditable } } = this.state
+    if (!isEditable) return null
     if (policyAccepted) return null
 
     return (

--- a/app/javascript/packs/MainApp/components/RefereeProfile.jsx
+++ b/app/javascript/packs/MainApp/components/RefereeProfile.jsx
@@ -35,7 +35,6 @@ class RefereeProfile extends Component {
       testResults: [],
       isEditable: false,
       submittedPaymentAt: null,
-      hasPendingPolicies: false,
     },
     paymentError: false,
     paymentSuccess: false,

--- a/app/serializers/referee_serializer.rb
+++ b/app/serializers/referee_serializer.rb
@@ -51,6 +51,12 @@ class RefereeSerializer
     current_user&.id == user.id
   end
 
+  attribute :has_pending_policies do |user, params|
+    current_user = params.present? && params[:current_user]
+
+    current_user&.id == user.id && user.pending_policies.present?
+  end
+
   has_many :national_governing_bodies, serializer: :national_governing_body
   has_many :referee_certifications, serializer: :referee_certification
   has_many :certifications, serializer: :certification

--- a/spec/controllers/api/v1/referees_controller_spec.rb
+++ b/spec/controllers/api/v1/referees_controller_spec.rb
@@ -117,6 +117,8 @@ RSpec.describe Api::V1::RefereesController, type: :controller do
   describe 'GET #show' do
     let!(:referee) { create :user }
 
+    before { allow_any_instance_of(User).to receive(:pending_policies).and_return([]) }
+
     subject { get :show, params: { id: referee.id } }
 
     it 'returns http success' do
@@ -170,7 +172,10 @@ RSpec.describe Api::V1::RefereesController, type: :controller do
     let!(:national_governing_bodies) { create_list :national_governing_body, 3 }
     let(:ngb_ids) { national_governing_bodies.pluck(:id) }
 
-    before { sign_in referee }
+    before do
+      sign_in referee
+      allow_any_instance_of(User).to receive(:pending_policies).and_return([])
+    end
 
     subject { post :update, params: body_data }
 


### PR DESCRIPTION
The pending policies api call was failing for non-admin users. Moving this check to the serializer prevents this being an issue.