### PR TITLE
Add csv templates

### DIFF
--- a/app/javascript/MainApp/pages/ImportWizard/ImportWizard.tsx
+++ b/app/javascript/MainApp/pages/ImportWizard/ImportWizard.tsx
@@ -108,7 +108,7 @@ const ImportWizard = (props: RouteComponentProps<ScopeParams>) => {
   }
 
   return (
-    <div className="w-full px-10 py-4 flex flex-col h-screen items-center">
+    <div className="w-full px-10 py-4 flex flex-col items-center">
       <div className="justify-start w-full">
         <button className="py-4 px-8 flex items-center text-xl" onClick={handleHomeClick}>
           <FontAwesomeIcon icon={faCaretLeft} className="mr-2" />
@@ -128,9 +128,15 @@ const ImportWizard = (props: RouteComponentProps<ScopeParams>) => {
       </div>
       <div className="rounded border border-gray-400 w-3/4">
         {renderStepContent()}
-      </div>
-      <div className="justify-end w-full flex mt-8">
-        <button className="green-button-outline" onClick={handleButtonClick} disabled={isDisabled}>{buttonText}</button>
+        <div className="justify-center mb-8 w-full flex">
+          <button
+            className="green-button-outline"
+            onClick={handleButtonClick}
+            disabled={isDisabled}
+          >
+            {buttonText}
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/app/javascript/MainApp/pages/ImportWizard/StepDescriptions.tsx
+++ b/app/javascript/MainApp/pages/ImportWizard/StepDescriptions.tsx
@@ -3,6 +3,12 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import classnames from 'classnames'
 import React from 'react'
 
+const stepTemplateMap: { [scope: string]: string } = {
+  'ngb': 'https://docs.google.com/spreadsheets/d/1Z5Wf-2CMYrXvk87gaglNRwZkO6tLuTolz6InhyJhpAQ/edit?usp=sharing',
+  'team': 'https://docs.google.com/spreadsheets/d/17NOk3OjKls8y2gih5PTz5Avw7wJ0mY_x3Cl-hkFOcrA/edit?usp=sharing',
+  'test': 'https://docs.google.com/spreadsheets/d/1TIGX1CpuSyaGJBwaZzVB1eb7zhw9BvjoWezgUaXbRKU/edit?usp=sharing'
+}
+
 interface StepDescriptionProps {
   currentStep: number;
   scope: string;
@@ -16,19 +22,30 @@ const StepDescriptions = (props: StepDescriptionProps) => {
     <div className="relative my-12 mx-auto">
       <div className="step-connector" />
       <div className="flex w-full z-1">
-        <div className={classnames("step-container", { ["text-navy-blue"]: isStepActive(1) })}>
-          <h3 className={classnames("step-number", { ["text-navy-blue"]: isStepActive(1) })}>Step 1</h3>
-          <div className={classnames("step-circle", { ["border-navy-blue"]: isStepActive(1) })}>
+        <div className={classnames("step-container", { ["step-active"]: isStepActive(1) })}>
+          <h3 className={classnames("step-number", { ["step-active"]: isStepActive(1) })}>Step 1</h3>
+          <div className={classnames("step-circle", { ["circle-active"]: isStepActive(1) })}>
             <FontAwesomeIcon icon={faUpload} />
           </div>
           <p>
             <span className="font-bold">Upload</span>
             {` your CSV file of ${scope} data.`}
           </p>
+          <p>
+            Need help? Download an example csv {' '}
+            <a
+              className="text-blue-darker hover:text-blue"
+              target="_blank"
+              rel="noopener noreferrer"
+              href={stepTemplateMap[scope]}
+            >
+              here
+            </a>
+          </p>
         </div>
-        <div className={classnames("step-container", { ["text-navy-blue"]: isStepActive(2) })}>
-          <h3 className={classnames("step-number", { ["text-navy-blue"]: isStepActive(2) })}>Step 2</h3>
-          <div className={classnames("step-circle", { ["border-navy-blue"]: isStepActive(2) })}>
+        <div className={classnames("step-container", { ["step-active"]: isStepActive(2) })}>
+          <h3 className={classnames("step-number", { ["step-active"]: isStepActive(2) })}>Step 2</h3>
+          <div className={classnames("step-circle", { ["circle-active"]: isStepActive(2) })}>
             <FontAwesomeIcon icon={faRoute} />
           </div>
           <p>
@@ -36,9 +53,9 @@ const StepDescriptions = (props: StepDescriptionProps) => {
             {` your custom headers to the required headers`}
           </p>
         </div>
-        <div className={classnames("step-container", { ["text-navy-blue"]: isStepActive(3) })}>
-          <h3 className={classnames("step-number", { ["text-navy-blue"]: isStepActive(3) })}>Step 3</h3>
-          <div className={classnames("step-circle", { ["border-navy-blue"]: isStepActive(3) })}>
+        <div className={classnames("step-container", { ["step-active"]: isStepActive(3) })}>
+          <h3 className={classnames("step-number", { ["step-active"]: isStepActive(3) })}>Step 3</h3>
+          <div className={classnames("step-circle", { ["circle-active"]: isStepActive(3) })}>
             <FontAwesomeIcon icon={faEnvelopeOpenText} />
           </div>
           <p>

--- a/app/javascript/stylesheets/application.css
+++ b/app/javascript/stylesheets/application.css
@@ -227,7 +227,7 @@
     @apply border-gray-400;
     @apply absolute;
     top: 36px;
-    left: 145px;
+    left: 150px;
     width: 70%;
     z-index: -1;
 }
@@ -239,6 +239,14 @@
     @apply text-gray-400;
     @apply mx-12;
     width: 33.33%
+}
+
+.step-active {
+    color: #2F3F57 !important;
+}
+
+.circle-active {
+    border-color: #2F3F57 !important;
 }
 
 .step-number {

--- a/app/models/exported_csv.rb
+++ b/app/models/exported_csv.rb
@@ -41,14 +41,15 @@ class ExportedCsv < ApplicationRecord
     current_time = Time.now.utc
     iso_time = format('%10.5f', current_time.to_f).to_i
     type_folder = ExportedCsv.format_type(type).parameterize(separator: '_')
-    key = "exports/#{type_folder}/#{iso_time}.csv"
+    key = "#{type_folder}/#{iso_time}.csv"
 
     url = Services::S3::Uploader.new(
       key: key,
       data: csv_data,
       content_type: 'text/csv',
       extension: 'csv',
-      public_access: false
+      public_access: false,
+      bucket_name: "#{user.id}-exports"
     ).perform
 
     self.url = url

--- a/app/services/manage_team_joined_change.rb
+++ b/app/services/manage_team_joined_change.rb
@@ -1,0 +1,88 @@
+module Services
+  class ManageTeamJoinedChange
+    attr_reader :prev_date, :new_date, :team, :all_stats
+    attr_accessor :stats_to_add, :stats_to_remove
+
+    def initialize(prev_date:, new_date:, team:)
+      @prev_date = prev_date
+      @new_date = new_date
+      @team = team
+      @all_stats = @team.national_governing_body.stats
+    end
+
+    # potential cases
+    # 1. new date is before the previous date
+    #    - update all later stats except the one that includes prev date, don't remove
+    # 2. new date is in the same month as the previous date
+    #    - no changes
+    # 3. new date is after the previous date
+    #    - remove the stats in the diff between dates
+    def perform
+      new_stat_index, prev_stat_index = find_indexes
+      return if new_stat_index == prev_stat_index
+
+      if new_stat_index >= 0
+        stats_to_add = most_recent_ordered_stats[prev_stat_index..new_stat_index] if new_stat_index > prev_stat_index
+        if prev_stat_index > new_stat_index
+          stats_to_remove = most_recent_ordered_stats[new_stat_index..prev_stat_index]
+        end
+      elsif prev_stat_index > 0
+        # remove one from the previous stats, as they are now invalid
+        last_stat_date = most_recent_ordered_stats.first.end_time
+        if new_date > last_stat_date
+          stats_to_remove = most_recent_ordered_stats[0..prev_stat_index]
+        else
+          # new date is in the past, add to all stats up to the prev stat
+          stats_to_add = most_recent_ordered_stats[(prev_stat_index + 1)..-1]
+        end
+      end
+
+      stats_to_add&.each { |stat| update_stat('add', stat) }
+      stats_to_remove&.each { |stat| update_stat('remove', stat) }
+    end
+
+    private
+
+    def most_recent_ordered_stats
+      @most_recent_ordered_stats ||= all_stats.order(end_time: :desc)
+    end
+
+    def includes_date?(stat, date)
+      (stat.start..stat.end_time).cover?(date)
+    end
+
+    def count_attrs
+      @count_attrs ||= {
+        team_status: "#{team.status}_teams_count",
+        team_group: "#{team.group_affiliation}_teams_count",
+      }
+    end
+
+    def update_stat(change_type, stat)
+      current_status_count = stat.send(count_attrs[:team_status])
+      current_group_count = stat.send(count_attrs[:team_group])
+      num_to_add = change_type == 'add' ? 1 : -1
+
+      if !team.other?
+        stat.assign_attributes(count_attrs[:team_status] => current_status_count + num_to_add)
+      end
+      if !team.not_applicable?
+        stat.assign_attributes(count_attrs[:team_group] => current_group_count + num_to_add)
+      end
+
+      stat.save!
+    end
+
+    def find_indexes(stats = most_recent_ordered_stats)
+      new_stat_index = -1
+      prev_stat_index = -1
+
+      stats.each_with_index do |stat, index|
+        prev_stat_index = index if includes_date?(stat, prev_date)
+        new_stat_index = index if includes_date?(stat, new_date)
+      end
+
+      return new_stat_index, prev_stat_index
+    end
+  end
+end

--- a/app/services/s3/uploader.rb
+++ b/app/services/s3/uploader.rb
@@ -7,15 +7,16 @@ module Services
 
       DEFAULT_ENCRYPTION = 'AES256'.freeze
 
-      attr_accessor :data, :content_type, :extension, :public_access, :encryption, :key
+      attr_accessor :data, :content_type, :extension, :public_access, :encryption, :key, :bucket_name
 
-      def initialize(data:, content_type:, extension:, public_access:, key:)
+      def initialize(data:, content_type:, extension:, public_access:, key:, bucket_name:)
         @data = data
         @content_type = content_type
         @extension = extension
         @public = public_access
         @encryption = DEFAULT_ENCRYPTION
         @key = key
+        @bucket_name = bucket_name
       end
 
       def perform
@@ -43,7 +44,6 @@ module Services
           provider: 'AWS',
           aws_access_key_id: aws_access_key_id,
           aws_secret_access_key: aws_secret_access_key,
-          region: 'eu-central-1'
         )
       end
 
@@ -68,12 +68,6 @@ module Services
         return 'nonsense' if Rails.env.test? || Rails.env.development?
 
         ENV['AWS_SECRET_ACCESS_KEY']
-      end
-
-      def bucket_name
-        return 'nonsense' if Rails.env.test? || Rails.env.development?
-
-        ENV['AWS_BUCKET']
       end
     end
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   config.assets.compile = false
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
+  config.action_controller.asset_host = 'http://d3r8w2muflqe0h.cloudfront.net/'
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache

--- a/spec/models/exported_csv_spec.rb
+++ b/spec/models/exported_csv_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe ExportedCsv, type: :model do
   let(:csv) { user.exported_csvs.last }
 
   before { Fog.mock! }
+  after { Fog::Mock.reset }
 
   subject { ExportedCsv::TeamExport.create!(user: user) }
 

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -42,4 +42,22 @@ RSpec.describe Team, type: :model do
       expect { subject }.to_not change { team.reload.team_status_changesets.count }
     end
   end
+
+  context 'when joined_at changes' do
+    let(:prev_date) { Date.new }
+    let(:new_date) { 10.days.ago }
+    let!(:team) { create :team, joined_at: prev_date }
+    let(:service_double) { double(:perform => :return_value) }
+
+    before { allow(Services::ManageTeamJoinedChange).to receive(:new).and_return(service_double) }
+
+    subject { team.update!(joined_at: new_date) }
+
+    it 'calls the manage service' do
+      expect(Services::ManageTeamJoinedChange).to receive(:new)
+        .with(prev_date: prev_date, new_date: new_date, team: team)
+
+      subject
+    end
+  end
 end

--- a/spec/services/manage_team_joined_change_spec.rb
+++ b/spec/services/manage_team_joined_change_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+describe Services::ManageTeamJoinedChange do
+  let!(:ngb) { create :national_governing_body }
+  let!(:team) { create :team, national_governing_body: ngb }
+  let!(:new_joined_date) { Date.new(2020, 4, 10) }
+  let!(:prev_joined_date) { Date.new(2020, 7, 10) }
+  let!(:stats) { create_list(:national_governing_body_stat, 8, national_governing_body: ngb) }
+
+  before do
+    stats.each_with_index do |stat, index|
+      new_time = Date.new(2020, index + 1, 10)
+      stat.update(start: new_time.beginning_of_month, end_time: new_time.end_of_month)
+    end
+  end
+
+  subject { described_class.new(prev_date: prev_joined_date, new_date: new_joined_date, team: team).perform }
+
+  it 'should update +1 the difference between the new date and prev date' do
+    expect { subject }.to change {
+      ngb.reload.stats.where(end_time: new_joined_date.end_of_month).first.competitive_teams_count
+    }.by(1)
+  end
+
+  context 'when prev date is older than the new date' do
+    let!(:new_joined_date) { Date.new(2020, 7, 10) }
+    let!(:prev_joined_date) { Date.new(2020, 4, 10) }
+
+    it 'should update -1 the difference between the prev date and the new date' do
+      expect { subject }.to change {
+        ngb.reload.stats.where(end_time: prev_joined_date.end_of_month).first.competitive_teams_count
+      }.by(-1)
+    end
+  end
+
+  context 'when new date is outside of the current stats' do
+    context 'when newer than the last stat' do
+      let!(:new_joined_date) { Date.new(2020, 9, 10) }
+      let!(:prev_joined_date) { Date.new(2020, 4, 10) }
+
+      it 'should update -1 the last stat' do
+        expect { subject }.to change {
+          ngb.reload.stats.order(end_time: :desc).first.competitive_teams_count
+        }.by(-1)
+      end
+
+      it 'should update -1 the difference between the prev date and the new date' do
+        expect { subject }.to change {
+          ngb.reload.stats.where(end_time: prev_joined_date.end_of_month).first.competitive_teams_count
+        }.by(-1)
+      end
+    end
+
+    context 'when older than the oldest stat' do
+      let!(:new_joined_date) { Date.new(2019, 8, 10) }
+      let!(:prev_joined_date) { Date.new(2020, 4, 10) }
+
+      it 'should update +1 the oldest stat' do
+        expect { subject }.to change {
+          ngb.reload.stats.order(end_time: :desc).last.competitive_teams_count
+        }.by(1)
+      end
+    end
+  end
+
+  context "when the team doesn't have a stat value" do
+    let(:team) { create :team, group_affiliation: 'not_applicable', status: 'other' }
+
+    it 'should not update the stat' do
+      expect { subject }.to_not change {
+        ngb.reload.stats.where(end_time: new_joined_date.end_of_month).first.competitive_teams_count
+      }
+    end
+  end
+end

--- a/spec/services/s3/uploader_spec.rb
+++ b/spec/services/s3/uploader_spec.rb
@@ -9,9 +9,9 @@ describe Services::S3::Uploader do
   let(:key) { 'team_export.csv' }
   let(:extension) { 'csv' }
   let(:bucket_name) { "#{user.id}-exports" }
-  before do
-    Fog.mock!
-  end
+
+  before { Fog.mock! }
+  after { Fog::Mock.reset }
 
   subject do
     described_class.new(

--- a/spec/services/s3/uploader_spec.rb
+++ b/spec/services/s3/uploader_spec.rb
@@ -8,7 +8,7 @@ describe Services::S3::Uploader do
   let(:data) { ExportedCsv::TeamExport.new(user: user, export_options: export_options.to_json).generate_csv_data }
   let(:key) { 'team_export.csv' }
   let(:extension) { 'csv' }
-
+  let(:bucket_name) { "#{user.id}-exports" }
   before do
     Fog.mock!
   end
@@ -19,12 +19,13 @@ describe Services::S3::Uploader do
       content_type: 'text/csv',
       extension: extension,
       public_access: false,
-      key: key
+      key: key,
+      bucket_name: bucket_name,
     ).perform
   end
 
   it 'returns the created url' do
-    expect(subject).to eq "https://nonsense.s3.amazonaws.com/#{key}"
+    expect(subject).to eq "https://#{bucket_name}.s3.amazonaws.com/#{key}"
   end
 
   context 'with invalid data' do


### PR DESCRIPTION
This PR cleans up some bugs and styling issues that have come up during testing. Three major things have changed:

- AWS bucket creation is fixed so that exporting data actually works.
- CSV templates were added to the import wizard to help users import data correctly
- A service was added to manage ngb stats when a team's joined at is changed.