### PR TITLE
Uses more modern syntax to fetch/create the bucket

### DIFF
--- a/app/services/s3/uploader.rb
+++ b/app/services/s3/uploader.rb
@@ -39,7 +39,7 @@ module Services
 
       def storage
         Fog.mock! if Rails.env.test? || Rails.env.development?
-        
+
         @storage ||= Fog::Storage.new(
           provider: 'AWS',
           aws_access_key_id: aws_access_key_id,
@@ -48,14 +48,10 @@ module Services
       end
 
       def bucket
-        @bucket ||= begin
-          if storage.directories.blank?
-            # ensure the bucket is available to upload the file into
-            storage.put_bucket(bucket_name)
-          end
+        fetched_bucket = storage.directories.get(bucket_name)
+        return fetched_bucket unless fetched_bucket.blank?
 
-          storage.directories.get(bucket_name)
-        end
+        storage.directories.create(key: bucket_name, public: true)
       end
 
       def aws_access_key_id

--- a/spec/models/exported_csv_spec.rb
+++ b/spec/models/exported_csv_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe ExportedCsv, type: :model do
   let(:csv) { user.exported_csvs.last }
 
   before { Fog.mock! }
-  after { Fog::Mock.reset }
 
   subject { ExportedCsv::TeamExport.create!(user: user) }
 

--- a/spec/services/s3/uploader_spec.rb
+++ b/spec/services/s3/uploader_spec.rb
@@ -11,7 +11,6 @@ describe Services::S3::Uploader do
   let(:bucket_name) { "#{user.id}-exports" }
 
   before { Fog.mock! }
-  after { Fog::Mock.reset }
 
   subject do
     described_class.new(


### PR DESCRIPTION
The previous syntax used was a mix of deprecated and misaligned methods. This should be the final configuration of the uploader service.