### PR TITLE
Recertification test

### DIFF
--- a/app/controllers/api/v1/national_governing_bodies_controller.rb
+++ b/app/controllers/api/v1/national_governing_bodies_controller.rb
@@ -12,7 +12,10 @@ module Api
 
       def index
         page = params[:page] || 1
-        @national_governing_bodies = NationalGoverningBody.all.order(:name)
+        @national_governing_bodies = NationalGoverningBody
+          .includes(:social_accounts, :teams, :referees, :stats)
+          .all
+          .order(:name)
         ngbs_total = @national_governing_bodies.count
         @national_governing_bodies = @national_governing_bodies.page(page)
 

--- a/app/controllers/api/v1/tests_controller.rb
+++ b/app/controllers/api/v1/tests_controller.rb
@@ -126,7 +126,8 @@ module Api
           :time_limit,
           :active,
           :testable_question_count,
-          :certification_id
+          :certification_id,
+          :recertification
         )
       end
 

--- a/app/javascript/MainApp/components/modals/TestEditModal/TestEditModal.tsx
+++ b/app/javascript/MainApp/components/modals/TestEditModal/TestEditModal.tsx
@@ -4,10 +4,12 @@ import React, { useEffect, useState } from 'react'
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 
 import { UpdateTestRequest } from 'MainApp/apis/test';
+import Toggle from 'MainApp/components/Toggle';
 import { getCertifications } from 'MainApp/modules/certification/certifications';
 import { createTest, getTest, updateTest } from 'MainApp/modules/test/test';
 import { RootState } from 'MainApp/rootReducer';
 import { TestLevel } from 'MainApp/schemas/getTestSchema';
+
 import Modal, { ModalProps, ModalSize } from '../Modal/Modal';
 
 type UpdateCertification = {
@@ -38,6 +40,7 @@ const initialNewTest: UpdateTestRequest = {
   name: '',
   negativeFeedback: '',
   positiveFeedback: '',
+  recertification: false,
   testableQuestionCount: 0,
   timeLimit: 0,
 }
@@ -83,14 +86,14 @@ const TestEditModal = (props: TestEditModalProps) => {
   const hasError = (dataKey: string): boolean => errors?.includes(dataKey)
 
   useEffect(() => {
-    if (testId && !test) {
+    if (testId && testId !== test?.id) {
       dispatch(getTest(testId))
     }
-  }, [testId, dispatch])
+  }, [testId, test, dispatch])
 
   useEffect(() => {
-    if (test) {
-      setNewTest({ ...test.attributes })
+    if (test && testId) {
+      setNewTest({ ...test?.attributes })
       setNewCert({ level: certification.level, version: certification.version })
     }
   }, [test, certification])
@@ -130,6 +133,14 @@ const TestEditModal = (props: TestEditModalProps) => {
     } else {
       setNewTest({ ...newTest, [name]: value })
     }
+  }
+
+  const handleToggleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.currentTarget.checked
+
+    if (!hasChangedTest) setHasChangedTest(true)
+
+    setNewTest({ ...newTest, recertification: value })
   }
 
   const handleClose = () => {
@@ -321,6 +332,14 @@ const TestEditModal = (props: TestEditModalProps) => {
             />
             {renderError('timeLimit')}
           </label>
+        </div>
+        <div className="w-full text-left">
+          <Toggle
+            onChange={handleToggleChange}
+            name="recertification"
+            label="Recertification Test?"
+            checked={newTest.recertification}
+          />
         </div>
         <div className="w-full text-center">
           <button

--- a/app/javascript/MainApp/pages/Test/Details.tsx
+++ b/app/javascript/MainApp/pages/Test/Details.tsx
@@ -1,4 +1,4 @@
-import { kebabCase } from 'lodash'
+import { isBoolean, kebabCase } from 'lodash'
 import React from 'react'
 
 import { Data } from 'MainApp/schemas/getTestSchema';
@@ -12,15 +12,16 @@ const Details = (props: DetailsProps) => {
   const { test } = props
   const dataToRender = test ? test.attributes : [];
 
-  const renderData = (entry: [string, string]) => {
+  const renderData = (entry: [string, string | boolean]) => {
     if (EXCLUDED_ATTRIBUTES.includes(entry[0])) return null
 
     const labelText = kebabCase(entry[0]).split('-').join(' ')
+    const dataText = isBoolean(entry[1]) ? String(entry[1]) : entry[1]
 
     return (
       <div key={entry[0]} className="my-4">
         <label className="uppercase text-md font-hairline text-gray-400">{labelText}</label>
-        <p>{entry[1]}</p>
+        <p>{dataText}</p>
       </div>
     )
   }

--- a/app/javascript/MainApp/pages/Test/Test.tsx
+++ b/app/javascript/MainApp/pages/Test/Test.tsx
@@ -10,6 +10,7 @@ import TestEditModal from 'MainApp/components/modals/TestEditModal'
 import WarningModal from 'MainApp/components/modals/WarningModal'
 import QuestionsManager from 'MainApp/components/QuestionsManager'
 import Toggle from 'MainApp/components/Toggle'
+import { CurrentUserState } from 'MainApp/modules/currentUser/currentUser'
 import { exportTest } from 'MainApp/modules/job/job'
 import { deleteTest, getTest, updateTest } from 'MainApp/modules/test/test'
 import { RootState } from 'MainApp/rootReducer'
@@ -38,6 +39,9 @@ const NewTest = (props: RouteComponentProps<IdParams>) => {
   const dispatch = useDispatch()
   const history = useHistory()
   const { test, isLoading } = useSelector((state: RootState) => state.test, shallowEqual)
+  const { roles } = useSelector((state: RootState): CurrentUserState => state.currentUser, shallowEqual)
+  if (!roles.includes('iqa_admin')) history.goBack()
+
   const isSelected = (tab: SelectedTab) => selectedTab === tab
 
   useEffect(() => {

--- a/app/javascript/MainApp/schemas/getTestSchema.ts
+++ b/app/javascript/MainApp/schemas/getTestSchema.ts
@@ -37,6 +37,7 @@ export interface Attributes {
   testableQuestionCount?: number;
   updatedAt?: string;
   certificationId?: number;
+  recertification?: boolean;
 }
 
 export interface Included {

--- a/app/javascript/MainApp/schemas/getTestsSchema.ts
+++ b/app/javascript/MainApp/schemas/getTestsSchema.ts
@@ -33,6 +33,7 @@ export interface Attributes {
   testableQuestionCount: number;
   updatedAt: string;
   certificationId: number;
+  recertification: boolean;
 }
 
 export interface Included {

--- a/app/models/exported_csv/test_export.rb
+++ b/app/models/exported_csv/test_export.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: exported_csvs
+#
+#  id             :bigint           not null, primary key
+#  export_options :json             not null
+#  processed_at   :datetime
+#  sent_at        :datetime
+#  type           :string
+#  url            :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  user_id        :integer          not null
+#
+# Indexes
+#
+#  index_exported_csvs_on_user_id  (user_id)
+#
 require 'csv'
 
 class ExportedCsv::TestExport < ExportedCsv

--- a/app/models/test.rb
+++ b/app/models/test.rb
@@ -11,6 +11,7 @@
 #  name                    :string
 #  negative_feedback       :text
 #  positive_feedback       :text
+#  recertification         :boolean          default(FALSE)
 #  testable_question_count :integer          default(0), not null
 #  time_limit              :integer          default(18), not null
 #  created_at              :datetime         not null
@@ -28,9 +29,9 @@ class Test < ApplicationRecord
   belongs_to :certification
 
   has_many :questions, dependent: :destroy
-  has_many :referee_answers, dependent: :destroy
-  has_many :test_attempts, dependent: :destroy
-  has_many :test_results, dependent: :destroy
+  has_many :referee_answers, dependent: :nullify
+  has_many :test_attempts, dependent: :nullify
+  has_many :test_results, dependent: :nullify
 
   enum level: {
     snitch: 0,
@@ -39,60 +40,7 @@ class Test < ApplicationRecord
   }
 
   scope :active, -> { where(active: true) }
-
-  def self.csv_import(file) # rubocop:disable Metrics/MethodLength
-    tests = []
-
-    CSV.foreach(file.path, headers: true) do |row|
-      row_data = row.to_h.with_indifferent_access
-      all_keys = row_data.keys
-      new_test = Test.new(
-        description: row_data.dig(:description),
-        language: row_data.dig(:language),
-        level: row_data.dig(:level),
-        minimum_pass_percentage: row_data.dig(:minimum_pass_percentage),
-        name: row_data.dig(:name),
-        negative_feedback: row_data.dig(:negative_feedback),
-        positive_feedback: row_data.dig(:positive_feedback),
-        testable_question_count: row_data.dig(:question_count),
-        time_limit: row_data.dig(:time_limit)
-      )
-      next unless new_test.valid?
-
-      question_keys = all_keys.select { |key| key =~ /question_\d+$/ }
-      questions = []
-      question_keys.each do |question_key|
-        new_question = Question.new(
-          description: row_data.dig("#{question_key}_description"),
-          feedback: row_data.dig("#{question_key}_feedback"),
-          points_available: row_data.dig("#{question_key}_points_available")
-        )
-
-        question_number = question_key.split('_')[-1].to_i
-        answer_keys = all_keys.select { |key| key =~ /answer_#{question_number}\w$/ }
-        answers = []
-        answer_keys.each do |answer_key|
-          new_answer = Answer.new(
-            description: row_data.dig("#{answer_key}_description"),
-            correct: row_data.dig("#{answer_key}_correct")
-          )
-
-          answers << new_answer
-        end
-
-        new_question.answers = answers
-        questions << new_question
-      end
-
-      new_test.questions = questions
-      tests << new_test
-    end
-
-    Test.import tests, recursive: true
-  rescue => exception
-    Bugsnag.notify(exception)
-    logger.error exception
-  end
+  scope :recertification, -> { where(recertification: true) }
 
   def fetch_random_questions
     questions.limit(testable_question_count).order(Arel.sql('RANDOM()'))

--- a/app/serializers/test_serializer.rb
+++ b/app/serializers/test_serializer.rb
@@ -11,6 +11,7 @@
 #  name                    :string
 #  negative_feedback       :text
 #  positive_feedback       :text
+#  recertification         :boolean          default(FALSE)
 #  testable_question_count :integer          default(0), not null
 #  time_limit              :integer          default(18), not null
 #  created_at              :datetime         not null

--- a/app/serializers/test_serializer.rb
+++ b/app/serializers/test_serializer.rb
@@ -31,7 +31,8 @@ class TestSerializer < BaseSerializer
              :active,
              :testable_question_count,
              :updated_at,
-             :certification_id
+             :certification_id,
+             :recertification
 
   belongs_to :certification
 end

--- a/db/migrate/20200920181132_add_recertification_to_tests.rb
+++ b/db/migrate/20200920181132_add_recertification_to_tests.rb
@@ -1,0 +1,5 @@
+class AddRecertificationToTests < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tests, :recertification, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_29_232341) do
+ActiveRecord::Schema.define(version: 2020_09_20_181132) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -306,6 +306,7 @@ ActiveRecord::Schema.define(version: 2020_07_29_232341) do
     t.string "language"
     t.boolean "active", default: false, null: false
     t.integer "testable_question_count", default: 0, null: false
+    t.boolean "recertification", default: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/tests.rb
+++ b/spec/factories/tests.rb
@@ -11,6 +11,7 @@
 #  name                    :string
 #  negative_feedback       :text
 #  positive_feedback       :text
+#  recertification         :boolean          default(FALSE)
 #  testable_question_count :integer          default(0), not null
 #  time_limit              :integer          default(18), not null
 #  created_at              :datetime         not null


### PR DESCRIPTION
Adds a recertification flag for tests so referees that have already earned certification will be given the more difficult version of tests. Also fixes an n+1 on the ngb index call.

Closes #225 