### PR TITLE
Recertification Failure Email

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -19,4 +19,11 @@ class UserMailer < ApplicationMailer
 
     mail(to: @user.email, subject: "Your #{export_type} is ready")
   end
+
+  def recertification_failure_email
+    @test_result = params[:test_result]
+    @referee = params[:referee]
+
+    mail(to: 'gameplay@iqasport.org', subject: "#{@test_result.test.name} Recertification Failure")
+  end
 end

--- a/app/views/user_mailer/recertification_failure_email.html.erb
+++ b/app/views/user_mailer/recertification_failure_email.html.erb
@@ -1,0 +1,11 @@
+<p>
+  A recertification attempt has failed for referee: <%= @referee.full_name %>
+</p>
+
+<p>
+  They attempted <%= @test_result.test.name %> (<%= @test_result.test.certification.version %>) in <%= @test_result.duration %> with <%= @test_result.points_scored %> points scored out of <%= @test_result.points_available %> points available
+</p>
+
+<p>
+  If necessary, please adjust their certifications <a href="https://manage.iqasport.com/referees/<%= @referee.id %>">here</a>
+</p>

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -65,4 +65,41 @@ class UserMailerPreview < ActionMailer::Preview
 
     UserMailer.with(user: user, csv: csv).export_csv_email
   end
+
+  def recertification_failure_email
+    started_at = Time.now.utc.to_s
+    finished_at = (Time.now.utc + 15.minutes).to_s
+
+    referee = User.create(
+      first_name: 'Test',
+      last_name: 'Testerton',
+      email: "#{FFaker::Name.first_name}.tester@example.com",
+      password: 'password'
+    )
+    referee.confirm_all_policies!
+
+    test = Test.create!(
+      level: 'snitch',
+      name: 'Snitch Referee Test',
+      negative_feedback: 'You did bad',
+      positive_feedback: 'You did good',
+      description: 'A snitch test',
+      certification: Certification.find_by(level: 'snitch')
+    )
+
+    test_result = TestResult.create!(
+      test: test,
+      duration: '00:15:00',
+      passed: false,
+      minimum_pass_percentage: 50,
+      percentage: 10,
+      points_available: 100,
+      points_scored: 10,
+      time_finished: finished_at,
+      time_started: started_at,
+      referee: referee
+    )
+
+    UserMailer.with(referee: referee, test_result: test_result).recertification_failure_email
+  end
 end


### PR DESCRIPTION
Adds a notification email sent to gameplay whenever someone fails a recertification test. This will be used by gameplay to manually adjust previously earned certifications. 