### PR TITLE
Migrate test languages

### DIFF
--- a/db/data/20201017215307_migrate_language_to_new_language.rb
+++ b/db/data/20201017215307_migrate_language_to_new_language.rb
@@ -1,0 +1,19 @@
+class MigrateLanguageToNewLanguage < ActiveRecord::Migration[6.0]
+  def up
+    Test.all.find_each do |t|
+      current_language = t.language
+      current_region = nil
+      current_region = 'ES' if current_language =~ /Europa/
+      current_region = '419' if current_language =~ /Latinoamérica/
+      current_language = 'Español' if current_language =~ /Español/
+      new_language = Language.find_by(long_name: current_language, short_region: current_region)
+      new_language = Language.find_by(long_name: 'English') unless new_language.present?
+
+      t.update(new_language_id: new_language.id)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20201016201032)
+DataMigrate::Data.define(version: 20201017215307)


### PR DESCRIPTION
Adds new_language_ids from existing language fields on tests. Does not include dropping the column or renaming it. 

Closes #230 