### PR TITLE
Finds ref cert by cert id

### DIFF
--- a/app/controllers/api/v1/referee_certifications_controller.rb
+++ b/app/controllers/api/v1/referee_certifications_controller.rb
@@ -56,7 +56,7 @@ module Api
       end
 
       def find_referee_certification
-        @referee_certification = user_scope.referee_certifications.find_by(id: params[:id])
+        @referee_certification = user_scope.referee_certifications.find_by(certification_id: params[:id])
       end
 
       def find_certification(level)

--- a/app/javascript/MainApp/components/tables/Table/Table.tsx
+++ b/app/javascript/MainApp/components/tables/Table/Table.tsx
@@ -74,7 +74,7 @@ const Table = <T extends Referee | Test | Team | Ngb>(props: TableProps<T>) => {
 
   return (
     <>
-      {items.length > 0 && (
+      {items?.length > 0 && (
         <table className="rounded-table-header">
           <tbody>
             <tr className="text-left">
@@ -92,7 +92,7 @@ const Table = <T extends Referee | Test | Team | Ngb>(props: TableProps<T>) => {
       )}
       <div className={classnames("table-container", { 'full-height-table': !isHeightRestricted })}>
         <table className="rounded-table">
-          {items.length ? renderBody() : renderEmpty()}
+          {items?.length ? renderBody() : renderEmpty()}
         </table>
       </div>
     </>

--- a/spec/controllers/api/v1/referee_certifications_controller_spec.rb
+++ b/spec/controllers/api/v1/referee_certifications_controller_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Api::V1::RefereeCertificationsController, type: :controller do
     subject { put :update, params: body_data }
 
     context 'with valid params' do
-      let(:body_data) { { id: assistant.id, needs_renewal_at: Time.zone.now, referee_id: referee.id } }
+      let(:body_data) { { id: assistant.certification.id, needs_renewal_at: Time.zone.now, referee_id: referee.id } }
 
       it_behaves_like 'it is a successful request'
 


### PR DESCRIPTION
Previously we were mis-matching the certification id and the ref certification id. This caused issues where you were able to actually revoke a certification. Also fixes a small frontend bug that kept popping up on bugsnag.