### PR TITLE
Showing the right test and questions

### DIFF
--- a/app/javascript/MainApp/components/modals/CheckoutModal/CheckoutModal.tsx
+++ b/app/javascript/MainApp/components/modals/CheckoutModal/CheckoutModal.tsx
@@ -7,6 +7,7 @@ import { createSession } from 'MainApp/modules/checkout/checkout';
 import { getProducts } from 'MainApp/modules/checkout/products';
 import { fetchCurrentUser } from 'MainApp/modules/currentUser/currentUser';
 import { RootState } from 'MainApp/rootReducer';
+import { Datum } from 'MainApp/schemas/getCertificationsSchema';
 import { GetProductsSchema } from 'MainApp/schemas/getProductsSchema';
 
 import Loader from '../../Loader';
@@ -27,7 +28,14 @@ const CheckoutModal = (props: CheckoutModalProps) => {
   const { certificationPayments, currentUser } = useSelector((state: RootState) => state.currentUser, shallowEqual)
 
   const showLoader = isLoading || isRedirect
-  const hasPaidForCerts = certificationPayments.length === products.length
+  const hasPaidForAllCerts = (): boolean => {
+    const unpaidProducts = products.filter((product) => {
+      const certificationId = findCertification(product)?.id
+      return !certificationPayments.includes(parseInt(certificationId, 10))
+    })
+
+    return !unpaidProducts.length
+  }
 
   useEffect(() => {
     if (!products?.length && !productsError) {
@@ -66,7 +74,7 @@ const CheckoutModal = (props: CheckoutModalProps) => {
     }
   }, [sessionId])
 
-  const findCertification = (product: GetProductsSchema) => {
+  const findCertification = (product: GetProductsSchema): Datum => {
     let version = 'twenty'
     if (product.name.match(/2018/)) version = 'eighteen'
 
@@ -106,20 +114,29 @@ const CheckoutModal = (props: CheckoutModalProps) => {
   }
 
   return (
-    <Modal open={props.open} showClose={true} size={ModalSize.Large} onClose={props.onClose}>
-      <h1 className="font-bold text-xl text-navy-blue text-center">Head Ref Certifications</h1>
+    <Modal
+      open={props.open}
+      showClose={true}
+      size={ModalSize.Large}
+      onClose={props.onClose}
+    >
+      <h1 className="font-bold text-xl text-navy-blue text-center">
+        Head Ref Certifications
+      </h1>
       {!showLoader && products?.map(renderProduct)}
-      {hasPaidForCerts && (
-        <h2
-          className="text-center text-lg text-navy-blue my-8"
-        >
+      {hasPaidForAllCerts() && (
+        <h2 className="text-center text-lg text-navy-blue my-8">
           All certifications paid for, you may close this window
         </h2>
       )}
       {showLoader && <Loader />}
-      {productsError && <h2 className="text-center text-lg text-navy-blue my-8">{productsError}</h2>}
+      {productsError && (
+        <h2 className="text-center text-lg text-navy-blue my-8">
+          {productsError}
+        </h2>
+      )}
     </Modal>
-  )
+  );
 }
 
 export default CheckoutModal

--- a/app/javascript/MainApp/pages/StartTest/StartTest.tsx
+++ b/app/javascript/MainApp/pages/StartTest/StartTest.tsx
@@ -68,7 +68,9 @@ const StartTest = (props: RouteComponentProps<TestParams>) => {
   const history = useHistory()
   const dispatch = useDispatch()
   const { test, error: testError, isLoading: testLoading } = useSelector((state: RootState) => state.test, shallowEqual)
-  const { questions, answers, error: questionsError } = useSelector((state: RootState) => state.questions, shallowEqual)
+  const { questions, answers, isLoading: questionsLoading, error: questionsError } = useSelector(
+    (state: RootState) => state.questions, shallowEqual
+  )
 
   useEffect(() => {
     if (!test || test.id !== testId) {
@@ -77,13 +79,14 @@ const StartTest = (props: RouteComponentProps<TestParams>) => {
   }, [testId, test])
 
   useEffect(() => {
-    if (questions.length && answers.length && !testLoading) {
+    const questionsMatchTest = questions[0]?.attributes.testId === parseInt(testId, 10)
+    if (!questionsLoading && questionsMatchTest) {
       const formattedQuestions = formatQuestions(questions, answers)
       setTestQuestions(formattedQuestions)
-      setStartedAt(DateTime.local())
       setCurrentQuestion(formattedQuestions[0])
+      setStartedAt(DateTime.local())
     }
-  }, [questions, answers])
+  }, [questions, answers, questionsLoading, testId])
 
   const isLastQuestion = currentQuestionIndex === testQuestions.length - 1
   const isFirstQuestion = currentQuestionIndex === 0
@@ -93,7 +96,9 @@ const StartTest = (props: RouteComponentProps<TestParams>) => {
     history.push(`/referees/${refereeId}`)
   }
 
-  const handleStartTest = () => dispatch(startTest(testId))
+  const handleStartTest = () => {
+    dispatch(startTest(testId))
+  }
 
   const handleNext = () => {
     const newIndex = currentQuestionIndex + 1


### PR DESCRIPTION
A couple of issues are addressed with this PR:

- Sometimes user's were shown the wrong tests, especially those with no certifications and with multiple test attempts. All specs added to the find_available_user_tests service failed before the code change.
- We were loading stale questions before a user started a test after they had just finished a different test, resulting in the wrong questions being shown to the user. In a recent PR we block these answers from being graded as a fail safe, so a referee's attempts are not affected when this happens, but it's still not great.
- Adjusts how we check for certification payments, the previous implementation was too naive.