### PR TITLE
Only return referee information if they are the current user or an admin

### DIFF
--- a/app/controllers/api/v1/referees_controller.rb
+++ b/app/controllers/api/v1/referees_controller.rb
@@ -3,6 +3,7 @@ module Api
     class RefereesController < ApplicationController # rubocop:disable Metrics/ClassLength
       before_action :authenticate_user!, only: :update
       before_action :verify_ngb_or_iqa_admin, only: :export
+      before_action :verify_ngb_or_iqa_admin_or_user
       before_action :find_referee, only: %i[show update tests]
       skip_before_action :verify_authenticity_token
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,6 +45,12 @@ class ApplicationController < ActionController::Base
     render json: { error: USER_UNAUTHORIZED }, status: :unauthorized
   end
 
+  def verify_ngb_or_iqa_admin_or_user
+    return true if current_user&.ngb_admin? || current_user&.iqa_admin? || current_user&.id == params[:id]
+
+    render json: { error: USER_UNAUTHORIZED }, status: :unauthorized
+  end
+
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:accept_invitation, keys: %i[first_name last_name policy_rule_privacy_terms])
     devise_parameter_sanitizer.permit(:invite, keys: [:ngb_to_admin])


### PR DESCRIPTION
Part of locking down the API from leaking a lot of private information. Only return the referee if it's for the current user or if it's an admin.