### PR TITLE
Correctly choose latest test attempt to check the cooldown period

### DIFF
--- a/app/controllers/api/v1/tests_controller.rb
+++ b/app/controllers/api/v1/tests_controller.rb
@@ -155,7 +155,7 @@ module Api
       end
 
       def verify_valid_cool_down
-        last_test_attempt = referee_test_attempts.last
+        last_test_attempt = referee_test_attempts.first
 
         return true unless last_test_attempt&.in_cool_down_period?
 


### PR DESCRIPTION
**Motivation**
Users reported being able to retake the AR test before 24 hours have elapsed. This has been verified by checking the database and there has been a number of people doing it, probably not realizing they shouldn't.

**Technical details**
The latest test attempt was being chosen incorrectly, actually taking the first test attempt of a given level (which would only work if you took one test before). This was a one line fix.

The reason it hasn't been caught before is that the test has been written incorrectly, mocking the response of `:in_cool_down_period?` instead of actually testing the logic.