### PR TITLE
Fix error when importing test CSV with custom headers

### DIFF
--- a/app/services/test_csv_import.rb
+++ b/app/services/test_csv_import.rb
@@ -52,7 +52,7 @@ module Services
       new_question = build_new_question(row_data)
 
       mapped_keys = mapped_headers.keys.select { |key| key =~ /answer_\d+/ }
-      answer_keys = mapped_keys.select { |key| mapped_headers[key] }
+      answer_keys = mapped_keys.map { |key| mapped_headers[key] }
 
       answers = []
       answer_keys.each { |answer_key| answers << build_new_answer(row_data, answer_key) }

--- a/spec/services/test_csv_import_spec.rb
+++ b/spec/services/test_csv_import_spec.rb
@@ -53,4 +53,46 @@ describe Services::TestCsvImport do
       expect { subject }.to raise_error { Services::TestCsvImport::TestMissingError }
     end
   end
+
+  context 'with custom headers' do
+    let(:headers) do
+      'q description,feedback,points available,correct answer,answer 1,answer 2,answer 3,answer 4'
+    end
+    let(:row1) { 'to be or not to be?,do better,1,answer 1,be,maybe,not be,never' }
+    let(:row2) { 'should you be the best?,also do better,1,answer 2,yes,sometimes,no,never' }
+    let(:row3) { "are you already the best?,why can't you do better,1,answer 3,possibly,maybe,kind of,never" }
+    let(:rows) { [headers, row1, row2, row3] }
+    let!(:csv) do
+      CSV.open(file_path, 'w') do |csv|
+        rows.each { |row| csv << row.split(',') }
+      end
+    end
+    let(:mapped_headers) do
+      {
+        'description': 'q description',
+        'feedback': 'feedback',
+        'points_available': 'points available',
+        'correct_answer': 'correct answer',
+        'answer_1': 'answer 1',
+        'answer_2': 'answer 2',
+        'answer_3': 'answer 3',
+        'answer_4': 'answer 4'
+      }
+    end
+
+    subject { described_class.new(file_path, test_to_import, mapped_headers.to_json).perform }
+
+    it 'creates 3 questions with answers' do
+      expect { subject }.to change { test_to_import.questions.count }.by 3
+    end
+  
+    it 'creates the answers for the provided questions' do
+      subject
+  
+      expect(test_to_import.questions.first.answers.count).to eq 4
+      expect(test_to_import.questions.first.answers.pluck(:description)).to eq ['be', 'maybe', 'not be', 'never']
+      expect(test_to_import.questions.first.answers.first.correct).to eq true
+      expect(test_to_import.questions.first.answers.last.correct).to eq false
+    end
+  end
 end

--- a/spec/services/test_csv_import_spec.rb
+++ b/spec/services/test_csv_import_spec.rb
@@ -18,14 +18,14 @@ describe Services::TestCsvImport do
   end
   let(:mapped_headers) do
     {
-      'description': 'description',
-      'feedback': 'feedback',
-      'points_available': 'points_available',
-      'correct_answer': 'correct_answer',
-      'answer_1': 'answer_1',
-      'answer_2': 'answer_2',
-      'answer_3': 'answer_3',
-      'answer_4': 'answer_4'
+      description: 'description',
+      feedback: 'feedback',
+      points_available: 'points_available',
+      correct_answer: 'correct_answer',
+      answer_1: 'answer_1',
+      answer_2: 'answer_2',
+      answer_3: 'answer_3',
+      answer_4: 'answer_4'
     }
   end
 
@@ -69,14 +69,14 @@ describe Services::TestCsvImport do
     end
     let(:mapped_headers) do
       {
-        'description': 'q description',
-        'feedback': 'feedback',
-        'points_available': 'points available',
-        'correct_answer': 'correct answer',
-        'answer_1': 'answer 1',
-        'answer_2': 'answer 2',
-        'answer_3': 'answer 3',
-        'answer_4': 'answer 4'
+        description: 'q description',
+        feedback: 'feedback',
+        points_available: 'points available',
+        correct_answer: 'correct answer',
+        answer_1: 'answer 1',
+        answer_2: 'answer 2',
+        answer_3: 'answer 3',
+        answer_4: 'answer 4'
       }
     end
 
@@ -85,10 +85,10 @@ describe Services::TestCsvImport do
     it 'creates 3 questions with answers' do
       expect { subject }.to change { test_to_import.questions.count }.by 3
     end
-  
+
     it 'creates the answers for the provided questions' do
       subject
-  
+
       expect(test_to_import.questions.first.answers.count).to eq 4
       expect(test_to_import.questions.first.answers.pluck(:description)).to eq ['be', 'maybe', 'not be', 'never']
       expect(test_to_import.questions.first.answers.first.correct).to eq true


### PR DESCRIPTION
There was a bug, where answer columns had to be in form `answer_N` and the mapped value of a custom header was not used. Added test case to verify.