### PR TITLE
Add 'twentytwo' rulebook version

### DIFF
--- a/app/javascript/MainApp/components/modals/CheckoutModal/CheckoutModal.tsx
+++ b/app/javascript/MainApp/components/modals/CheckoutModal/CheckoutModal.tsx
@@ -82,8 +82,9 @@ const CheckoutModal = (props: CheckoutModalProps) => {
   }, [sessionId]);
 
   const findCertification = (product: GetProductsSchema): Datum => {
-    let version = "twenty";
-    if (product.name.match(/2018/)) version = "eighteen";
+    let version = "twentytwo";
+    if (product.name.match(/2018-/)) version = "eighteen";
+    else if (product.name.match(/2020-/)) version = "twenty";
 
     return certifications?.find(
       ({ attributes }) => attributes.level === "head" && attributes.version === version

--- a/app/javascript/MainApp/components/modals/TestEditModal/TestEditModal.tsx
+++ b/app/javascript/MainApp/components/modals/TestEditModal/TestEditModal.tsx
@@ -31,7 +31,7 @@ const REQUIRED_TEST_FIELDS = [
 ];
 const REQUIRED_CERT_FIELDS = ["version", "level"];
 const LEVEL_OPTIONS = ["snitch", "assistant", "head", "field", "scorekeeper"];
-const VERSION_OPTIONS = ["eighteen", "twenty"];
+const VERSION_OPTIONS = ["eighteen", "twenty", "twentytwo"];
 
 const initialNewTest: UpdateTestRequest = {
   certificationId: null,

--- a/app/javascript/MainApp/components/tables/RefereeTable/RefereeTable.tsx
+++ b/app/javascript/MainApp/components/tables/RefereeTable/RefereeTable.tsx
@@ -32,7 +32,12 @@ const findHighestCert = (referee: Referee): string => {
   if (!Object.keys(certHashMap).length) return "Uncertified";
 
   const highestTwenty = certHashMap.twenty?.sort(sortByLength)[0];
+  const highestTwentyTwo = certHashMap.twentytwo?.sort(sortByLength)[0];
   const highestEighteen = certHashMap.eighteen?.sort(sortByLength)[0];
+
+  if (highestTwentyTwo?.length > 0 && highestTwentyTwo?.length < highestTwenty?.length) {
+    return `${capitalize(highestTwentyTwo)} ${getVersion("twentytwo")}`;
+  }
 
   if (highestTwenty?.length > 0 && highestTwenty?.length < highestEighteen?.length) {
     return `${capitalize(highestTwenty)} ${getVersion("twenty")}`;

--- a/app/javascript/MainApp/factories/certification.ts
+++ b/app/javascript/MainApp/factories/certification.ts
@@ -4,7 +4,7 @@ import { Factory } from "fishery";
 import { Datum } from "../schemas/getCertificationsSchema";
 
 const levels = ["assistant", "snitch", "head", "field", "scorekeeper"];
-const versions = ["eighteen", "twenty"];
+const versions = ["eighteen", "twenty", "twentytwo"];
 
 export default Factory.define<Datum>(({ sequence }) => ({
   attributes: {

--- a/app/javascript/MainApp/utils/certUtils.ts
+++ b/app/javascript/MainApp/utils/certUtils.ts
@@ -7,6 +7,8 @@ export const getVersion = (version: string): string => {
       return "2018-2020";
     case "twenty":
       return "2020-2021";
+    case "twentytwo":
+      return "2022-2023";
     default:
       return "Unknown";
   }

--- a/app/javascript/MainApp/utils/certUtils.ts
+++ b/app/javascript/MainApp/utils/certUtils.ts
@@ -8,7 +8,7 @@ export const getVersion = (version: string): string => {
     case "twenty":
       return "2020-2021";
     case "twentytwo":
-      return "2022-2023";
+      return "2022-2024";
     default:
       return "Unknown";
   }

--- a/app/models/certification.rb
+++ b/app/models/certification.rb
@@ -32,6 +32,7 @@ class Certification < ApplicationRecord
   # refers to the year the rulebook version was released
   enum version: {
     eighteen: 0,
-    twenty: 1
+    twenty: 1,
+    twentytwo: 2
   }
 end

--- a/config/stripe/products.rb
+++ b/config/stripe/products.rb
@@ -29,3 +29,9 @@ Stripe.product :head_twenty do |product|
 
   product.type = 'service'
 end
+
+Stripe.product :head_twentytwo do |product|
+  product.name = 'Head Referee Exam Fee (Rulebook 2022-2024)'
+
+  product.type = 'service'
+end


### PR DESCRIPTION
This should make it possible to define new tests in the referee hub for IQA Rulebook 2022