### PR TITLE
Prevent unauthenticated access to endpoints that contain PII

### DIFF
--- a/app/controllers/api/v1/national_governing_bodies_controller.rb
+++ b/app/controllers/api/v1/national_governing_bodies_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class NationalGoverningBodiesController < ApplicationController
-      before_action :authenticate_user!, only: %i[show update update_logo]
+      before_action :authenticate_user!
       before_action :find_ngb, only: %i[show update update_logo]
       before_action :verify_update_admin, only: %i[update update_logo]
       before_action :verify_valid_update_params, only: %i[update]

--- a/app/controllers/api/v1/referees_controller.rb
+++ b/app/controllers/api/v1/referees_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class RefereesController < ApplicationController # rubocop:disable Metrics/ClassLength
-      before_action :authenticate_user!, only: %i[show update]
+      before_action :authenticate_user!
       before_action :verify_ngb_or_iqa_admin, only: :export
       before_action :find_referee, only: %i[show update tests]
       skip_before_action :verify_authenticity_token

--- a/spec/controllers/api/v1/referees_controller_spec.rb
+++ b/spec/controllers/api/v1/referees_controller_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Api::V1::RefereesController, type: :controller do
   describe 'GET #index' do
     let!(:referees) { create_list :user, 3 }
 
+    before { sign_in referees[0] }
+
     subject { get :index }
 
     it_behaves_like 'it is a successful request'


### PR DESCRIPTION
Accessing `/api/v1/referees` returns data of all referees even in unauthenticated context. There's no reason to suspect this endpoint has been accessed improperly. 