### PR TITLE
Disambiguate pending sub-states in registration list view

### DIFF
--- a/src/frontend/app/pages/Tournaments/TournamentId/RegistrationsModal.tsx
+++ b/src/frontend/app/pages/Tournaments/TournamentId/RegistrationsModal.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import {
   useGetTournamentInvitesQuery,
   useRespondToInviteMutation,
+  TournamentInviteViewModel,
 } from "../../../store/serviceApi";
 import StatusBadge from "../../../components/StatusBadge";
 import ActionButtonPair from "../../../components/ActionButtonPair";
@@ -84,6 +85,12 @@ const RegistrationsModal = forwardRef<RegistrationsModalRef>((_props, ref) => {
   }
 
   const selectedInviteData = invites?.find((i) => i.participantId === selectedInvite);
+
+  function getPendingLabel(invite: TournamentInviteViewModel): string {
+    if (invite.tournamentManagerApproval?.status === "pending") return "Awaiting your review";
+    if (invite.participantApproval?.status === "pending") return "Awaiting team response";
+    return "Pending";
+  }
 
   return (
     <>
@@ -234,6 +241,9 @@ const RegistrationsModal = forwardRef<RegistrationsModalRef>((_props, ref) => {
                                 year: "numeric",
                               })}
                             </p>
+                            {invite.status === "pending" && (
+                              <p className="text-xs text-amber-700 mt-0.5">{getPendingLabel(invite)}</p>
+                            )}
                           </div>
                           <StatusBadge status={invite.status || "unknown"} />
                         </div>


### PR DESCRIPTION
A single "Pending" badge covered two meaningfully different states in the registrations list: a team awaiting tournament manager review vs. a team that hasn't yet responded to a manager-sent invite.

## Changes

- **`RegistrationsModal.tsx`**: Added `getPendingLabel` to surface the correct sub-state as amber sub-text beneath the team name in the list view:
  - `"Awaiting your review"` — team-initiated join request, tournament manager action needed
  - `"Awaiting team response"` — manager-sent invite, waiting on team acceptance
- Imported `TournamentInviteViewModel` to type the helper function

```tsx
function getPendingLabel(invite: TournamentInviteViewModel): string {
  if (invite.tournamentManagerApproval?.status === "pending") return "Awaiting your review";
  if (invite.participantApproval?.status === "pending") return "Awaiting team response";
  return "Pending";
}

// In list row:
{invite.status === "pending" && (
  <p className="text-xs text-amber-700 mt-0.5">{getPendingLabel(invite)}</p>
)}
```