### PR TITLE
Show hidden Ref certification onClick

### DIFF
--- a/src/frontend/app/pages/RefereeProfile/RefereeHeader/RefereeHeader.test.tsx
+++ b/src/frontend/app/pages/RefereeProfile/RefereeHeader/RefereeHeader.test.tsx
@@ -176,7 +176,7 @@ describe("RefereeHeader", () => {
     expect(screen.getByText("+2")).toBeInTheDocument();
   });
 
-  test("it reveals hidden certifications on hover of the +N badge", () => {
+  test("it reveals hidden certifications when clicking the +N badge", () => {
     const manyCerts: Certification[] = [
       { level: "head", version: "twentyfour" },
       { level: "snitch", version: "twentytwo" },
@@ -187,15 +187,12 @@ describe("RefereeHeader", () => {
 
     const overflowBadge = screen.getByText("+2");
 
-    // Tooltip should not be visible before hover
-    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    expect(screen.queryByText("Flag (2022-2023)")).not.toBeInTheDocument();
+    expect(screen.queryByText("Assistant (2024)")).not.toBeInTheDocument();
 
-    // Hover over the outer wrapper span (parentElement has the onMouseEnter handler)
-    fireEvent.mouseEnter(overflowBadge.parentElement!);
-    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+    fireEvent.click(overflowBadge);
 
-    // Mouse leave hides the tooltip
-    fireEvent.mouseLeave(overflowBadge.parentElement!);
-    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    expect(screen.getByText("Flag (2022-2023)")).toBeInTheDocument();
+    expect(screen.getByText("Assistant (2024)")).toBeInTheDocument();
   });
 });

--- a/src/frontend/app/pages/RefereeProfile/RefereeHeader/RefereeHeader.tsx
+++ b/src/frontend/app/pages/RefereeProfile/RefereeHeader/RefereeHeader.tsx
@@ -73,7 +73,7 @@ const RefereeHeader = (props: HeaderProps) => {
   const { data: userAvatar } = useGetUserAvatarQuery({ userId: refereeId });
   const { data: user } = useGetUserDataQuery({ userId: refereeId });
 
-  const [showTooltip, setShowTooltip] = useState(false);
+  const [showHiddenCerts, setShowHiddenCerts] = useState(false);
 
   const headerCerts = pickHeaderCerts(certifications ?? []);
 
@@ -110,52 +110,46 @@ const RefereeHeader = (props: HeaderProps) => {
 
         {/* Overflow badge — shows remaining cert count with a hover tooltip */}
         {hiddenCerts.length > 0 && (
-          <span
-            style={{ position: "relative", display: "inline-flex" }}
-            onMouseEnter={() => setShowTooltip(true)}
-            onMouseLeave={() => setShowTooltip(false)}
-          >
-            <span
-              style={{
-                background: "#e5e7eb",
-                color: "#374151",
-                border: "1px solid #d1d5db",
-                padding: "0.2rem 0.6rem",
-                borderRadius: "9999px",
-                fontSize: "0.75rem",
-                fontWeight: 600,
-                cursor: "default",
-              }}
-              aria-label={`${hiddenCerts.length} more certifications`}
-            >
-              +{hiddenCerts.length}
-            </span>
-
-            {showTooltip && (
-              <div
-                role="tooltip"
+          <>
+            {!showHiddenCerts && (
+              <button
+                type="button"
                 style={{
-                  position: "absolute",
-                  bottom: "calc(100% + 6px)",
-                  left: "50%",
-                  transform: "translateX(-50%)",
-                  background: "#1f2937",
-                  color: "#f9fafb",
-                  borderRadius: "0.375rem",
-                  padding: "0.4rem 0.6rem",
+                  background: "#e5e7eb",
+                  color: "#374151",
+                  border: "1px solid #d1d5db",
+                  padding: "0.2rem 0.6rem",
+                  borderRadius: "9999px",
                   fontSize: "0.75rem",
-                  whiteSpace: "nowrap",
-                  zIndex: 10,
-                  pointerEvents: "none",
-                  boxShadow: "0 2px 8px rgba(0,0,0,0.25)",
+                  fontWeight: 600,
+                  cursor: "pointer",
                 }}
+                aria-label={`Show ${hiddenCerts.length} more certifications`}
+                aria-expanded={showHiddenCerts}
+                onClick={() => setShowHiddenCerts(true)}
               >
-                {hiddenCerts.map((cert) => (
-                  <div key={`${cert.level}-${cert.version}`}>{renderCertLabel(cert)}</div>
-                ))}
-              </div>
+                +{hiddenCerts.length}
+              </button>
             )}
-          </span>
+
+            {showHiddenCerts &&
+              hiddenCerts.map((cert) => (
+                <span
+                  key={`${cert.level}-${cert.version}`}
+                  style={{
+                    background: "#dcfce7",
+                    color: "#166534",
+                    border: "1px solid #86efac",
+                    padding: "0.2rem 0.6rem",
+                    borderRadius: "9999px",
+                    fontSize: "0.75rem",
+                    fontWeight: 600,
+                  }}
+                >
+                  {renderCertLabel(cert)}
+                </span>
+              ))}
+          </>
         )}
 
         {onTakeTests && (


### PR DESCRIPTION
Expand certifications on click instead of tooltip on hover.